### PR TITLE
Enhancements/Bugfixes for safe + PKI backend

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,15 @@
+# New Features
+
+- Added `safe dhparam` for generating randomized DH params,
+  and storing the PEM data in the secret backend.
+
+# Improvements
+
+- `safe crl-pem` and `safe ca-pem` now support a path argument,
+  triggering `safe` to store the corresponding PEM data in the
+  secret backend, at `path`.
+
+# Bug Fixes
+
+- `safe cert` no longer stomps on pre-existing values stored
+  in the path at which the cert is being generated.

--- a/main.go
+++ b/main.go
@@ -150,6 +150,11 @@ func main() {
            Vaults PKI backend. If path is supplied, sets the "crl-pem" key using the
            current CRL inside the secret backend, at <path>.
 
+    dhparam [bits] path
+           Generates DH Params using OpenSSL, and the specified bit length. Defaults
+           to 2048 bit primes. Primes are then stored in <path> under the 'dhparam-pem'
+           key.
+
     prompt ...
            Echo the arguments, space-separated, as a single line to the terminal.
 
@@ -588,6 +593,33 @@ func main() {
 		}
 		return nil
 	})
+
+	r.Dispatch("dhparam", func(command string, args ...string) error {
+		rc.Apply()
+		bits := 2048
+
+		if len(args) > 0 {
+			if u, err := strconv.ParseUint(args[0], 10, 16); err == nil {
+				bits = int(u)
+				args = args[1:]
+			}
+		}
+
+		if len(args) < 1 {
+			return fmt.Errorf("USAGE: dhparam [bits] path")
+		}
+
+		path := args[0]
+		v := connect()
+		s, err := v.Read(path)
+		if err != nil && err != vault.NotFound {
+			return err
+		}
+		if err = s.DHParam(bits); err != nil {
+			return err
+		}
+		return v.Write(path, s)
+	}, "dh", "dhparams")
 
 	r.Dispatch("prompt", func(command string, args ...string) error {
 		fmt.Fprintf(os.Stderr, "%s\n", strings.Join(args, " "))

--- a/vault/dhparam.go
+++ b/vault/dhparam.go
@@ -1,0 +1,19 @@
+package vault
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func genDHParam(bits int) (string, error) {
+	cmd := exec.Command("openssl", "dhparam", fmt.Sprintf("%d", bits))
+	cmd.Stderr = os.Stderr
+
+	// output runs command and returns output
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+
 	"github.com/ghodss/yaml"
 	"github.com/kless/osutil/user/crypt/sha512_crypt"
 )
@@ -61,6 +62,15 @@ func (s *Secret) Format(oldKey, newKey, fmtType string) error {
 		return fmt.Errorf("%s is not a valid encoding for the `safe fmt` command", fmtType)
 	}
 
+	return nil
+}
+
+func (s *Secret) DHParam(length int) error {
+	dhparam, err := genDHParam(length)
+	if err != nil {
+		return err
+	}
+	s.Set("dhparam-pem", dhparam)
 	return nil
 }
 

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -489,7 +489,10 @@ func (v *Vault) CreateSignedCertificate(role, path string, params CertOptions) e
 					return fmt.Errorf("Invalid data type for serial_number %s:\n%v\n", cn, data)
 				}
 
-				secret := NewSecret()
+				secret, err := v.Read(path)
+				if err != nil && err != NotFound {
+					return err
+				}
 				secret.Set("cert", cert)
 				secret.Set("key", key)
 				secret.Set("serial", serial)


### PR DESCRIPTION
A bug fix for `safe cert`, enhancements to `safe ca-pem` and `safe crl-pem`, and support for generating dhparams via `safe dhparam`