### PR TITLE
Removed 'paste' command, and replaced with alias to 'set'

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -15,6 +15,8 @@
   triggering `safe` to store the corresponding PEM data in the
   secret backend, at `path`.
 
+- Merged `safe set` and `safe paste` into a single function using aliasing.
+
 # Bug Fixes
 
 - `safe cert` no longer stomps on pre-existing values stored

--- a/main.go
+++ b/main.go
@@ -312,28 +312,7 @@ func main() {
 			s.Set(k, v)
 		}
 		return v.Write(path, s)
-	}, "write")
-
-	r.Dispatch("paste", func(command string, args ...string) error {
-		rc.Apply()
-		if len(args) < 2 {
-			return fmt.Errorf("USAGE: set path key[=value] [key ...]")
-		}
-		v := connect()
-		path, args := args[0], args[1:]
-		s, err := v.Read(path)
-		if err != nil && err != vault.NotFound {
-			return err
-		}
-		for _, set := range args {
-			k, v, err := keyPrompt(set, false)
-			if err != nil {
-				return err
-			}
-			s.Set(k, v)
-		}
-		return v.Write(path, s)
-	})
+	}, "write", "paste")
 
 	r.Dispatch("get", func(command string, args ...string) error {
 		rc.Apply()


### PR DESCRIPTION
Was testing the `get-attr` branch, and tried out the paste command, but it didn't work as I expected, and looked like it was a straight up clone of `set`, so I consolidated them. 