### PR TITLE
Use HTTP proxies defined by env var $HTTP_PROXY

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -18,6 +18,7 @@ func authurl(base, f string, args ...interface{}) string {
 func authenticate(req *http.Request) (string, error) {
 	client := &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: os.Getenv("VAULT_SKIP_VERIFY") != "",
 			},

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -44,6 +44,7 @@ func NewVault(url, token string) (*Vault, error) {
 		Token: token,
 		Client: &http.Client{
 			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: os.Getenv("VAULT_SKIP_VERIFY") != "",
 				},


### PR DESCRIPTION
This PR allows safe to use a proxy server configured via $HTTP_PROXY and
$HTTPS_PROXY environment variables.