### PR TITLE
Improvements to key parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ release
 ci/credentials.yml
 /t
 /vaults
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ release
 ci/credentials.yml
 /t
 /vaults
+.vscode

--- a/main.go
+++ b/main.go
@@ -355,7 +355,11 @@ func main() {
 			fmt.Printf("--- # %s\n", path)
 			//Don't show key if specific key was requested
 			if _, key := vault.ParsePath(path); key != "" {
-				fmt.Println(s.SingleValue())
+				value, err := s.SingleValue()
+				if err != nil {
+					return err
+				}
+				fmt.Println(value)
 			} else {
 				fmt.Println(s.YAML())
 			}

--- a/main.go
+++ b/main.go
@@ -307,7 +307,7 @@ func main() {
 		v := connect()
 		path, args := args[0], args[1:]
 		s, err := v.Read(path)
-		if err != nil && err != vault.NotFound {
+		if err != nil && !vault.IsNotFound(err) {
 			return err
 		}
 		for _, set := range args {
@@ -328,7 +328,7 @@ func main() {
 		v := connect()
 		path, args := args[0], args[1:]
 		s, err := v.Read(path)
-		if err != nil && err != vault.NotFound {
+		if err != nil && !vault.IsNotFound(err) {
 			return err
 		}
 		for _, set := range args {
@@ -353,7 +353,13 @@ func main() {
 				return err
 			}
 			fmt.Printf("--- # %s\n", path)
-			fmt.Printf("%s\n\n", s.YAML())
+			//Don't show key if specific key was requested
+			if _, key := vault.ParsePath(path); key != "" {
+				fmt.Println(s.SingleValue())
+			} else {
+				fmt.Println(s.YAML())
+			}
+			fmt.Println()
 		}
 		return nil
 	}, "read", "cat")
@@ -529,7 +535,7 @@ func main() {
 		v := connect()
 		path, key := args[0], args[1]
 		s, err := v.Read(path)
-		if err != nil && err != vault.NotFound {
+		if err != nil && !vault.IsNotFound(err) {
 			return err
 		}
 		s.Password(key, length)
@@ -557,7 +563,7 @@ func main() {
 		v := connect()
 		for _, path := range args {
 			s, err := v.Read(path)
-			if err != nil && err != vault.NotFound {
+			if err != nil && !vault.IsNotFound(err) {
 				return err
 			}
 			if err = s.SSHKey(bits); err != nil {
@@ -587,7 +593,7 @@ func main() {
 		v := connect()
 		for _, path := range args {
 			s, err := v.Read(path)
-			if err != nil && err != vault.NotFound {
+			if err != nil && !vault.IsNotFound(err) {
 				return err
 			}
 			if err = s.RSAKey(bits); err != nil {
@@ -618,7 +624,7 @@ func main() {
 		path := args[0]
 		v := connect()
 		s, err := v.Read(path)
-		if err != nil && err != vault.NotFound {
+		if err != nil && !vault.IsNotFound(err) {
 			return err
 		}
 		if err = s.DHParam(bits); err != nil {
@@ -665,7 +671,7 @@ func main() {
 			return err
 		}
 		if err = s.Format(oldKey, newKey, fmtType); err != nil {
-			if err == vault.NotFound {
+			if vault.IsNotFound(err) {
 				return fmt.Errorf("%s:%s does not exist, cannot create %s encoded copy at %s:%s", path, oldKey, fmtType, path, newKey)
 			}
 			return fmt.Errorf("Error encoding %s:%s as %s: %s", path, oldKey, fmtType, err)
@@ -686,7 +692,7 @@ func main() {
 		if len(args) > 0 {
 			path := args[0]
 			s, err := v.Read(path)
-			if err != nil && err != vault.NotFound {
+			if err != nil && !vault.IsNotFound(err) {
 				return err
 			}
 			s.Set("crl-pem", string(pem))
@@ -713,7 +719,7 @@ func main() {
 		if len(args) > 0 {
 			path := args[0]
 			s, err := v.Read(path)
-			if err != nil && err != vault.NotFound {
+			if err != nil && !vault.IsNotFound(err) {
 				return err
 			}
 			s.Set("ca-pem", string(pem))

--- a/tests
+++ b/tests
@@ -169,7 +169,7 @@ EOF
 		testing ${version} tree not found errors
 		./safe tree secret/enoent >t/home/got 2>&1
 		cat >t/home/want <<EOF
-!! secret not found
+!! no secret exists at path \`secret/enoent\`
 EOF
 		diffok
 		;;

--- a/vault/errors.go
+++ b/vault/errors.go
@@ -2,10 +2,40 @@ package vault
 
 import (
 	"fmt"
+	"regexp"
 )
 
-var NotFound error
+var secretErrorRegexp, keyErrorRegexp *regexp.Regexp
+
+//IsNotFound returns true if the given error is a SecretNotFound error
+// 	or a KeyNotFound error. Returns false otherwise.
+func IsNotFound(err error) bool {
+	return isSecretNotFound(err) || isKeyNotFound(err)
+}
+
+//NewSecretNotFoundError returns an error with a message descibing the path
+// which could not be found in the secret backend.
+func NewSecretNotFoundError(path string) error {
+	return fmt.Errorf("no secret exists at path `%s`", path)
+}
+
+func isSecretNotFound(err error) bool {
+	return secretErrorRegexp.Match([]byte(err.Error()))
+}
+
+//NewKeyNotFoundError returns an error object describing the key that could not
+// be located within the secret it was searched for in. Returning a KeyNotFound
+// error should semantically mean that the secret it would've been contained in
+// was located in the vault.
+func NewKeyNotFoundError(path, key string) error {
+	return fmt.Errorf("no key `%s` exists in secret `%s`", key, path)
+}
+
+func isKeyNotFound(err error) bool {
+	return keyErrorRegexp.Match([]byte(err.Error()))
+}
 
 func init() {
-	NotFound = fmt.Errorf("secret not found")
+	secretErrorRegexp = regexp.MustCompile("^no secret exists at path `.*`$")
+	keyErrorRegexp = regexp.MustCompile("^no key `.*` exists in secret `.*`$")
 }

--- a/vault/errors_test.go
+++ b/vault/errors_test.go
@@ -1,0 +1,140 @@
+package vault
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// ADD TEST CASES HERE
+var testSecrets = [...]string{
+	"path/to/secret",
+	"1234901827",
+	"",
+	".*",
+}
+
+var testKeys = [...]string{
+	"key",
+	"a/key/this/is",
+	"1239487329",
+	"",
+	":",
+	".*",
+}
+
+var otherErrorMessages = [...]string{
+	"I am not a NotFoundError",
+	"looks/like/a/path",
+	"looks/like/a/path and looks/like/another/path",
+}
+
+var secretErrors, keyErrors, otherErrors []error
+
+func TestNewSecretNotFoundError(t *testing.T) {
+	for i, err := range secretErrors {
+		//It has the path in it!
+		testString := fmt.Sprintf("`%s`", testSecrets[i])
+		if !strings.Contains(err.Error(), testString) {
+			t.Errorf("Error message `%s` does not contain test string `%s`", err.Error(), testString)
+		}
+	}
+}
+
+func TestNewKeyNotFoundError(t *testing.T) {
+	for i, err := range keyErrors {
+		//It has the path and the key in it!
+		testSecretString := fmt.Sprintf("`%s`", testSecrets[i/len(testKeys)])
+		testKeyString := fmt.Sprintf("`%s`", testKeys[i%len(testKeys)])
+		for _, str := range []string{testSecretString, testKeyString} {
+			if !strings.Contains(err.Error(), str) {
+				t.Errorf("Error message `%s` does not contain test string `%s`", err.Error(), str)
+			}
+		}
+	}
+}
+
+func TestIsSecretNotFoundPositives(t *testing.T) {
+	for _, err := range secretErrors {
+		//It is recognized as a SecretNotFoundError
+		if !isSecretNotFound(err) {
+			t.Errorf("Error with message `%s` not recognized as SecretNotFoundError", err.Error())
+		}
+	}
+}
+
+func TestIsSecretNotFoundNegatives(t *testing.T) {
+	//Random other errors aren't SecretNotFoundErrors
+	for _, err := range otherErrors {
+		if isSecretNotFound(err) {
+			t.Errorf("Error with message `%s` was incorrectly recognized as a SecretNotFoundError", err.Error())
+		}
+	}
+	//KeyNotFoundError isn't a SecretNotFoundError
+	for _, err := range keyErrors {
+		if isSecretNotFound(err) {
+			t.Errorf("Error with message `%s` incorrectly recognized as SecretNotFoundError", err.Error())
+		}
+	}
+}
+
+func TestIsKeyNotFoundPositives(t *testing.T) {
+	for _, err := range keyErrors {
+		//It is recognized as a KeyNotFoundError
+		if !isKeyNotFound(err) {
+			t.Errorf("Error with message `%s` not recognized as KeyNotFoundError", err.Error())
+		}
+	}
+}
+
+func TestIsKeyNotFoundNegatives(t *testing.T) {
+	//Random other errors aren't recognized as KeyNotFoundErrors
+	for _, err := range otherErrors {
+		if isKeyNotFound(err) {
+			t.Errorf("Error with message `%s` was incorrectly recognized as a KeyNotFoundError", err.Error())
+		}
+	}
+	//SecretNotFoundErrors aren't KeyNotFoundErrors
+	for _, err := range secretErrors {
+		if isKeyNotFound(err) {
+			t.Errorf("Error with message `%s` incorrectly recognized as KeyNotFoundError", err.Error())
+		}
+	}
+}
+
+func TestIsNotFoundPositives(t *testing.T) {
+	//SecretNotFoundErrors are NotFoundErrors
+	for _, err := range secretErrors {
+		if !IsNotFound(err) {
+			t.Errorf("Error with message `%s` not recognized as NotFoundError", err.Error())
+		}
+	}
+	for _, err := range keyErrors {
+		if !IsNotFound(err) {
+			t.Errorf("Error with message `%s` not recognized as NotFoundError", err.Error())
+		}
+	}
+}
+
+func TestIsNotFoundNegatives(t *testing.T) {
+	for _, err := range otherErrors {
+		if IsNotFound(err) {
+			t.Errorf("Error with message `%s` incorrectly identified as NotFoundError", err.Error())
+		}
+	}
+}
+
+func init() {
+
+	// Initialize all the error objects
+	for _, secret := range testSecrets {
+		secretErrors = append(secretErrors, NewSecretNotFoundError(secret))
+		for _, key := range testKeys {
+			keyErrors = append(keyErrors, NewKeyNotFoundError(secret, key))
+		}
+	}
+
+	for _, msg := range otherErrorMessages {
+		otherErrors = append(otherErrors, fmt.Errorf(msg))
+	}
+}

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -46,7 +46,7 @@ func (s *Secret) Set(key, value string) {
 
 func (s *Secret) Format(oldKey, newKey, fmtType string) error {
 	if !s.Has(oldKey) {
-		return NotFound
+		return NewSecretNotFoundError(oldKey)
 	}
 	oldVal := s.Get(oldKey)
 	switch fmtType {
@@ -130,4 +130,18 @@ func (s *Secret) YAML() string {
 		return ""
 	}
 	return string(b)
+}
+
+// SingleValue converts a secret to a string representing the value extracted.
+// Returns an error if there are not exactly one results in the secret
+// object
+func (s *Secret) SingleValue() (string, error) {
+	if len(s.data) != 1 {
+		return "", fmt.Errorf("%d results in secret, 1 expected", len(s.data))
+	}
+	var ret string
+	for _, v := range s.data {
+		ret = v
+	}
+	return ret, nil
 }

--- a/vault/secret_test.go
+++ b/vault/secret_test.go
@@ -1,0 +1,30 @@
+package vault
+
+import "testing"
+
+func TestSingleValue(t *testing.T) {
+	for _, test := range []struct {
+		data      map[string]string //data to put in the secret object
+		expected  string            //string expected to be returned. ignored if shouldErr is true
+		shouldErr bool              //true if the err returned should not be equal to nil
+	}{
+		//-----TEST CASES GO HERE-----
+		{map[string]string{"key": "value"}, "value", false},
+		{map[string]string{"key": "value", "other": "value"}, "", true},
+		{map[string]string{"": "value"}, "value", false},
+		{map[string]string{}, "", true},
+		{nil, "", true},
+	} {
+		//TEST CODE
+		value, err := (&Secret{data: test.data}).SingleValue()
+		if !test.shouldErr {
+			if err != nil {
+				t.Errorf("SingleValue should not have erred but did \n\t data contents: %+v", test.data)
+			} else if value != test.expected {
+				t.Errorf("SingleValue:\n\t expected: %s\n\t actual: %s\n", test.expected, value)
+			}
+		} else if test.shouldErr && err == nil {
+			t.Errorf("SingleValue should have erred but did not\n\t data contents: %+v", test.data)
+		}
+	}
+}

--- a/vault/secret_test.go
+++ b/vault/secret_test.go
@@ -14,6 +14,7 @@ func TestSingleValue(t *testing.T) {
 		{map[string]string{"": "value"}, "value", false},
 		{map[string]string{}, "", true},
 		{nil, "", true},
+		{map[string]string{"secret": "multi\nline\nstring"}, "multi\nline\nstring", false},
 	} {
 		//TEST CODE
 		value, err := (&Secret{data: test.data}).SingleValue()

--- a/vault/utils.go
+++ b/vault/utils.go
@@ -1,19 +1,14 @@
 package vault
 
+import "strings"
+
 // ParsePath splits the given path string into its respective secret path
 //   and contained key parts
 func ParsePath(path string) (secret, key string) {
 	secret = path
-	if len(path) >= 2 { //must contain at least "a:", so two characters
-		for i := len(path) - 1; i >= 0; i-- {
-			if path[i] == ':' {
-				secret = path[0:i]
-				key = path[i+1 : len(path)]
-				break
-			}
-		}
-	} else if len(path) == 1 && path[0] == ':' { // if just ":"
-		secret = ""
+	if idx := strings.LastIndex(path, ":"); idx >= 0 {
+		secret = path[:idx]
+		key = path[idx+1:]
 	}
 	return
 }

--- a/vault/utils.go
+++ b/vault/utils.go
@@ -1,0 +1,19 @@
+package vault
+
+// ParsePath splits the given path string into its respective secret path
+//   and contained key parts
+func ParsePath(path string) (secret, key string) {
+	secret = path
+	if len(path) >= 2 { //must contain at least "a:", so two characters
+		for i := len(path) - 1; i >= 0; i-- {
+			if path[i] == ':' {
+				secret = path[0:i]
+				key = path[i+1 : len(path)]
+				break
+			}
+		}
+	} else if len(path) == 1 && path[0] == ':' { // if just ":"
+		secret = ""
+	}
+	return
+}

--- a/vault/utils_test.go
+++ b/vault/utils_test.go
@@ -1,0 +1,34 @@
+package vault
+
+import "testing"
+
+func TestParsePath(t *testing.T) {
+	for _, test := range []struct {
+		path      string //The full path to run through the parse function
+		expSecret string //What is expected to be left of the colon
+		expKey    string //What is expected to be right of the colon
+	}{
+		//-----TEST CASES GO HERE-----
+		// { "path to parse", "expected secret", "expected key" }
+		{"just/a/secret", "just/a/secret", ""},
+		{"secret/with/colon:", "secret/with/colon", ""},
+		{":", "", ""},
+		{"", "", ""},
+		{"secret/and:key", "secret/and", "key"},
+		{":justakey", "", "justakey"},
+		{"secretwithcolon://127.0.0.1:", "secretwithcolon://127.0.0.1", ""},
+		{"secretwithcolons://127.0.0.1:8500:", "secretwithcolons://127.0.0.1:8500", ""},
+		{"secretwithcolons://127.0.0.1:8500:andkey", "secretwithcolons://127.0.0.1:8500", "andkey"},
+	} {
+		secret, key := ParsePath(test.path)
+		if secret != test.expSecret || key != test.expKey {
+			t.Errorf(`Parsing '%s':
+			Expected:
+				Secret: '%s'
+				Key: '%s'
+			Actual:
+			 	Secret: '%s'
+				Key: '%s'`, test.path, test.expSecret, test.expKey, secret, key)
+		}
+	}
+}

--- a/vault/utils_test.go
+++ b/vault/utils_test.go
@@ -13,6 +13,7 @@ func TestParsePath(t *testing.T) {
 		{"just/a/secret", "just/a/secret", ""},
 		{"secret/with/colon:", "secret/with/colon", ""},
 		{":", "", ""},
+		{"a:", "a", ""},
 		{"", "", ""},
 		{"secret/and:key", "secret/and", "key"},
 		{":justakey", "", "justakey"},


### PR DESCRIPTION
Last colon wins when parsing keys from paths, e.g. `127.0.0.1:8500:key` becomes secret: `127.0.0.1:8500` and key: `key`.
Only value is returned on command line when a key is requested, as opposed to the full yaml with the key name.
Error messages for things not being found in the tree now have more information about what exactly couldn't be found. This involved making different kinds of error structs.
Unit tests were added for the things that were changed.

Addresses #49 
