### PR TITLE
Support `safe tree -d` semantics

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,6 @@
+## New Features
+
+- `safe tree` now takes an optional `-d` argument, which works
+  like that of the traditional filesystem `tree` utility and only
+  prints details for directory structures (not leaf nodes)
+  Fixes #48


### PR DESCRIPTION
`safe tree` now takes an optional `-d` argument, which works
like that of the traditional filesystem `tree` utility and only
prints details for directory structures (not leaf nodes)

Fixes #48