### PR TITLE
PKI Overhaul

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -4,3 +4,16 @@
   like that of the traditional filesystem `tree` utility and only
   prints details for directory structures (not leaf nodes)
   Fixes #48
+- `safe cert` now includes a `combined` attribute that contains
+  both the certificate and the key, in a single value, for when
+  you need that.
+- New `safe pki init` command will set up your PKI backend
+  configuration, if you'll take the time to answer a few simple
+  questions.  README updated accordingly.
+- Commands that need the `pki/` backend mounted now check if it is
+  mounted, and provide a hint to go run `safe pki init`
+
+## Bug Fixes
+
+- `safe ca-pem` no longer prints out duplicate PEM files.
+- `safe ca-pem` no longer prints out duplicate PEM files ;)


### PR DESCRIPTION
Lots of stuff got fixed up in the PKI experience with safe.
- `safe cert` now includes a `combined` attribute that contains
  both the certificate and the key, in a single value, for when
  you need that.
- New `safe pki init` command will set up your PKI backend
  configuration, if you'll take the time to answer a few simple
  questions.  README updated accordingly.
- Commands that need the `pki/` backend mounted now check if it is
  mounted, and provide a hint to go run `safe pki init`
- `safe ca-pem` no longer prints out duplicate PEM files.

Fixes #46
Fixes #47
