### PR TITLE
Implement seal/unseal/status ops for HA vaults

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,10 @@
+## Improvements
+
+- `safe` can now interrogate, seal and unseal HA backend Vaults,
+  if you are running the [strongbox][strongbox] helper utility on
+  your Consul+Vault deployment.  If you are running the shiny new
+  [safe BOSH release][bosh], you get the server-side bits for free!
+
+
+[strongbox]: https://github.com/jhunt/go-strongbox
+[bosh]:      https://github.com/cloudfoundry-community/safe-boshrelease

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -1,0 +1,94 @@
+package vault
+
+import (
+	"strings"
+	"regexp"
+	"net/http"
+	"encoding/json"
+	"io/ioutil"
+	"fmt"
+)
+
+func (v *Vault) SealKeys() (int, error) {
+	req, err := http.NewRequest("GET", v.url("/v1/sys/seal-status"), nil)
+	if err != nil {
+		return 0, err
+	}
+	res, err := v.request(req)
+	if err != nil {
+		return 0, err
+	}
+
+	if res.StatusCode != 200 {
+		return 0, fmt.Errorf("received HTTP %d response (to /v1/sys/seal-status)", res.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	var data = struct {
+		Keys int `json:"t"`
+	}{}
+	err = json.Unmarshal(b, &data)
+	if err != nil {
+		return 0, err
+	}
+	return data.Keys, nil
+}
+
+func (v *Vault) Seal() (bool, error) {
+	req, err := http.NewRequest("PUT", v.url("/v1/sys/seal"), nil)
+	if err != nil {
+		return false, err
+	}
+	res, err := v.request(req)
+	if err != nil {
+		return false, err
+	}
+
+	if res.StatusCode == 500 {
+		if b, err := ioutil.ReadAll(res.Body); err == nil {
+			if matched, _ := regexp.Match("cannot seal when in standby mode", b); matched {
+				return false, nil
+			}
+		}
+	}
+	if res.StatusCode != 204 {
+		return false, fmt.Errorf("received HTTP %d response", res.StatusCode)
+	}
+	return true, nil
+}
+
+func (v *Vault) Unseal(keys []string) error {
+	req, err := http.NewRequest("PUT", v.url("/v1/sys/unseal"), strings.NewReader(`{"reset":true}`))
+	if err != nil {
+		return err
+	}
+	res, err := v.request(req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("received HTTP %d response", res.StatusCode)
+	}
+
+	for _, k := range keys {
+		req, err := http.NewRequest("PUT", v.url("/v1/sys/unseal"), strings.NewReader(`{"key":"`+k+`"}`))
+		if err != nil {
+			return err
+		}
+		res, err := v.request(req)
+		if err != nil {
+			return err
+		}
+
+		if res.StatusCode != 200 {
+			return fmt.Errorf("received HTTP %d response", res.StatusCode)
+		}
+	}
+	return nil
+}
+

--- a/vault/strongbox.go
+++ b/vault/strongbox.go
@@ -1,0 +1,41 @@
+package vault
+
+import (
+	"fmt"
+	"io/ioutil"
+	"encoding/json"
+	"net/url"
+	"net/http"
+	"regexp"
+)
+
+func (v *Vault) Strongbox() (map[string] string, error) {
+	m := make(map[string] string)
+
+	u, err := url.Parse(v.URL)
+	if err != nil {
+		return m, err
+	}
+
+	c := &http.Client{}
+	re := regexp.MustCompile(`:[0-9]+$`)
+
+	uri := "http://" + re.ReplaceAllString(u.Host, "") + ":8484/strongbox"
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return m, err
+	}
+
+	res, err := c.Do(req)
+	if err != nil {
+		return m, err
+	}
+
+	if res.StatusCode != 200 {
+		return m, fmt.Errorf("received an HTTP %d response from %s", res.StatusCode, uri)
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	err = json.Unmarshal(b, &m)
+	return m, err
+}


### PR DESCRIPTION
*NOTE* all of this functionality relies on strongbox to determine safely
which Vaults are sealed and which are unsealed.  You can find the code
for that here: https://github.com/jhunt/go-strongbox

`safe seal` will interrogate strongbox to find all unsealed vaults,
and then seal those vaults transparently, waiting for background Consul
leader elections to take place.

`safe status` basically queries strongbox and pretty-prints what it
finds.  This is surprisingly useful.

`safe unseal` will find the sealed vaults, and determine how many seal
keys are required for an unseal.  It then prompts for the correct
number (up front) and then re-unseals all sealed backends.  It properly
resets seal progress on each backend first, to handle half-unsealed
Vaults.

This is an alternate implementation to PR #45, which is technically less
flexible (requires a helper component on the server deployment) but is
muuuuuuch simpler.