### PR TITLE
Updated several commands to work with `secret:key` syntax

### DIFF
--- a/main.go
+++ b/main.go
@@ -733,7 +733,7 @@ to get your bearings.
 					return err
 				}
 			} else {
-				if err := v.Delete(path); err != nil {
+				if err := v.Delete(path); err != nil && !vault.IsNotFound(err) {
 					return err
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -729,11 +729,11 @@ to get your bearings.
 				if !opt.Delete.Force && !recursively("delete", args...) {
 					return nil /* skip this command, process the next */
 				}
-				if err := v.DeleteTree(path); err != nil {
+				if err := v.DeleteTree(path); err != nil && !(vault.IsNotFound(err) && opt.Delete.Force) {
 					return err
 				}
 			} else {
-				if err := v.Delete(path); err != nil && !vault.IsNotFound(err) {
+				if err := v.Delete(path); err != nil && !(vault.IsNotFound(err) && opt.Delete.Force) {
 					return err
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -845,7 +845,7 @@ to get your bearings.
 
 		//Don't try to recurse if operating on a key
 		// args[0] is the source path. args[1] is the destination path.
-		if opt.Move.Recurse && !vault.PathHasKey(args[0]) && !vault.PathHasKey(args[1]) {
+		if opt.Copy.Recurse && !vault.PathHasKey(args[0]) && !vault.PathHasKey(args[1]) {
 			if !opt.Copy.Force && !recursively("copy", args...) {
 				return nil /* skip this command, process the next */
 			}

--- a/main.go
+++ b/main.go
@@ -724,7 +724,7 @@ to get your bearings.
 		for _, path := range args {
 			_, key := vault.ParsePath(path)
 			//Ignore -R if path has a key because that makes no sense
-			if opt.Delete.Recurse && key != "" {
+			if opt.Delete.Recurse && key == "" {
 				if !opt.Delete.Force && !recursively("delete", args...) {
 					return nil /* skip this command, process the next */
 				}
@@ -812,6 +812,7 @@ to get your bearings.
 		}
 
 		v := connect()
+
 		if opt.Move.Recurse {
 			if !opt.Move.Force && !recursively("move", args...) {
 				return nil /* skip this command, process the next */

--- a/main.go
+++ b/main.go
@@ -877,12 +877,16 @@ LENGTH defaults to 64 characters.
 			}
 		}
 
-		if len(args) != 2 {
-			r.ExitWithUsage("gen")
-		}
-
 		v := connect()
-		path, key := args[0], args[1]
+		var path, key string
+		if vault.PathHasKey(args[0]) {
+			path, key = vault.ParsePath(args[0])
+		} else {
+			if len(args) != 2 {
+				r.ExitWithUsage("gen")
+			}
+			path, key = args[0], args[1]
+		}
 		s, err := v.Read(path)
 		if err != nil && !vault.IsNotFound(err) {
 			return err

--- a/main.go
+++ b/main.go
@@ -820,11 +820,11 @@ to get your bearings.
 			if !opt.Move.Force && !recursively("move", args...) {
 				return nil /* skip this command, process the next */
 			}
-			if err := v.MoveCopyTree(args[0], args[1], v.Move); err != nil {
+			if err := v.MoveCopyTree(args[0], args[1], v.Move); err != nil && !(vault.IsNotFound(err) && opt.Move.Force) {
 				return err
 			}
 		} else {
-			if err := v.Move(args[0], args[1]); err != nil {
+			if err := v.Move(args[0], args[1]); err != nil && !(vault.IsNotFound(err) && opt.Move.Force) {
 				return err
 			}
 		}
@@ -849,11 +849,11 @@ to get your bearings.
 			if !opt.Copy.Force && !recursively("copy", args...) {
 				return nil /* skip this command, process the next */
 			}
-			if err := v.MoveCopyTree(args[0], args[1], v.Copy); err != nil {
+			if err := v.MoveCopyTree(args[0], args[1], v.Copy); err != nil && !(vault.IsNotFound(err) && opt.Copy.Force) {
 				return err
 			}
 		} else {
-			if err := v.Copy(args[0], args[1]); err != nil {
+			if err := v.Copy(args[0], args[1]); err != nil && !(vault.IsNotFound(err) && opt.Copy.Force) {
 				return err
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -320,7 +320,7 @@ func main() {
 	})
 
 	r.Dispatch("status", &Help{
-		Summary: "Print the status of the current targets backend nodes",
+		Summary: "Print the status of the current target's backend nodes",
 		Usage:   "safe status",
 		Type:    AdministrativeCommand,
 	}, func(command string, args ...string) error {
@@ -813,7 +813,9 @@ to get your bearings.
 
 		v := connect()
 
-		if opt.Move.Recurse {
+		//Don't try to recurse if operating on a key
+		// args[0] is the source path. args[1] is the destination path.
+		if opt.Move.Recurse && !vault.PathHasKey(args[0]) && !vault.PathHasKey(args[1]) {
 			if !opt.Move.Force && !recursively("move", args...) {
 				return nil /* skip this command, process the next */
 			}
@@ -840,7 +842,9 @@ to get your bearings.
 		}
 		v := connect()
 
-		if opt.Copy.Recurse {
+		//Don't try to recurse if operating on a key
+		// args[0] is the source path. args[1] is the destination path.
+		if opt.Move.Recurse && !vault.PathHasKey(args[0]) && !vault.PathHasKey(args[1]) {
 			if !opt.Copy.Force && !recursively("copy", args...) {
 				return nil /* skip this command, process the next */
 			}

--- a/tests
+++ b/tests
@@ -406,6 +406,38 @@ EOF
 	./safe set secret/copy/from8 foo=bar
 	./safe copy secret/copy/from8:beep secret/copy/to8; exitok $? 1
 
+	testing $version copying recursively from a leaf node secret
+	./safe set secret/copy/from9 foo=bar
+	./safe copy -Rf secret/copy/from9 secret/copy/to9; exitok $? 0
+	cat >t/home/want <<EOF
+bar
+EOF
+	./safe get secret/copy/from9:foo >t/home/got 2>t/home/errors; diffok
+	./safe get secret/copy/to9:foo >t/home/got 2>t/home/errors; diffok
+
+	testing $version copying recursively from a key
+	./safe set secret/copy/from10 foo=bar
+	./safe copy -Rf secret/copy/from10:foo secret/copy/to10; exitok $? 0
+	cat >t/home/want <<EOF
+bar
+EOF
+	./safe get secret/copy/from9:foo >t/home/got 2>t/home/errors; diffok
+	./safe get secret/copy/to9:foo >t/home/got 2>t/home/errors; diffok
+
+	testing $version copying recursively from a subtree
+	./safe set secret/copy/fromtree1/one foo=bar
+	./safe copy -Rf secret/copy/fromtree1 secret/copy/totree1; exitok $? 0
+	cat >t/home/want <<EOF
+bar
+EOF
+	./safe get secret/copy/fromtree1/one:foo >t/home/got 2>t/home/errors; diffok
+	./safe get secret/copy/totree1/one:foo >t/home/got 2>t/home/errors; diffok
+
+	testing $version attempting to copy a subtree without -R should fail
+	./safe set secret/copy/fromtree2/one foo=bar
+	./safe copy -f secret/copy/fromtree2 secret/copy/totree2; exitok $? 1
+	./safe get secret/copy/totree2/one; exitok $? 1
+
 	###### MOVE TESTS ######
 
 	testing $version move a secret to another location
@@ -488,6 +520,41 @@ EOF
 	testing $version moving from a missing key where the underlying secret exists should fail
 	./safe set secret/move/from8 foo=bar
 	./safe move secret/move/from8:beep secret/move/to8; exitok $? 1
+
+
+	testing $version moving recursively from a leaf node secret
+	./safe set secret/move/from9 foo=bar
+	./safe move -Rf secret/move/from9 secret/move/to9; exitok $? 0
+	cat >t/home/want <<EOF
+bar
+EOF
+	./safe get secret/move/from9; exitok $? 1
+	./safe get secret/move/to9:foo >t/home/got 2>t/home/errors; diffok
+
+
+	testing $version moving recursively from a key
+	./safe set secret/move/from10 foo=bar
+	./safe move -Rf secret/move/from10:foo secret/move/to10; exitok $? 0
+	cat >t/home/want <<EOF
+bar
+EOF
+	./safe get secret/move/from9; exitok $? 1
+	./safe get secret/copy/to9:foo >t/home/got 2>t/home/errors; diffok
+
+
+	testing $version moving recursively from a subtree
+	./safe set secret/move/fromtree1/one foo=bar
+	./safe move -Rf secret/move/fromtree1 secret/move/totree1; exitok $? 0
+	cat >t/home/want <<EOF
+bar
+EOF
+	./safe get secret/move/fromtree1/one; exitok $? 1
+	./safe get secret/move/totree1/one:foo >t/home/got 2>t/home/errors; diffok
+
+	testing $version attempting to copy a subtree without -R should fail
+	./safe set secret/move/fromtree2/one foo=bar
+	./safe move -f secret/move/fromtree2 secret/move/totree2; exitok $? 1
+	./safe get secret/move/totree2/one; exitok $? 1
 
   ###### TREE TESTS ######
 

--- a/tests
+++ b/tests
@@ -276,10 +276,10 @@ EOF
 	testing $version delete non-existent key should not fail if -f is given
 	./safe delete secret/delete/gobbledegook -f; exitok $? 0
 
-	testing $version attempt to delete non-existing key within existing secret should error
+	testing $version deleting non-existent key with -f specified should fail silently
 	./safe set secret/delete/eight foo=bar
 	./safe delete secret/delete/eight:gobbledegook -f; exitok $? 0
-	./safe get secret/delete/seven:foo; exitok $? 0
+	./safe get secret/delete/eight:foo; exitok $? 0
 
 	testing $version recursively delete a subtree
 	./safe set secret/delete/subtree1/one foo=bar

--- a/tests
+++ b/tests
@@ -421,8 +421,8 @@ EOF
 	cat >t/home/want <<EOF
 bar
 EOF
-	./safe get secret/copy/from9:foo >t/home/got 2>t/home/errors; diffok
-	./safe get secret/copy/to9:foo >t/home/got 2>t/home/errors; diffok
+	./safe get secret/copy/from10:foo >t/home/got 2>t/home/errors; diffok
+	./safe get secret/copy/to10:foo >t/home/got 2>t/home/errors; diffok
 
 	testing $version copying recursively from a subtree
 	./safe set secret/copy/fromtree1/one foo=bar
@@ -437,6 +437,15 @@ EOF
 	./safe set secret/copy/fromtree2/one foo=bar
 	./safe copy -f secret/copy/fromtree2 secret/copy/totree2; exitok $? 1
 	./safe get secret/copy/totree2/one; exitok $? 1
+
+	testing $version copying a non-existent secret with -f should fail silently
+	./safe copy -f secret/copy/gobbledegook secret/copy/fakedest; exitok $? 0
+	./safe get secret/copy/fakedest; exitok $? 1
+
+	testing $version copying a non-existent key with -f should fail silently
+	./safe set secret/copy/from11 foo=bar
+	./safe copy -f secret/copy/from11:beep secret/copy/to11; exitok $? 0
+	./safe get secret/copy/to11; exitok $? 1
 
 	###### MOVE TESTS ######
 
@@ -555,6 +564,20 @@ EOF
 	./safe set secret/move/fromtree2/one foo=bar
 	./safe move -f secret/move/fromtree2 secret/move/totree2; exitok $? 1
 	./safe get secret/move/totree2/one; exitok $? 1
+
+	testing $version moving a non-existent secret with -f should fail silently
+	./safe move -f secret/move/gobbledegook secret/move/fakedest; exitok $? 0
+	./safe get secret/move/fakedest; exitok $? 1
+
+	testing $version moving a non-existent key with -f should fail silently
+	./safe set secret/move/from11 foo=bar
+	./safe copy -f secret/move/from11:beep secret/move/to11; exitok $? 0
+	./safe get secret/move/to11; exitok $? 1
+	cat >t/home/want <<EOF
+bar
+EOF
+	./safe get secret/move/from11:foo >t/home/got 2>t/home/errors; diffok
+
 
   ###### TREE TESTS ######
 

--- a/tests
+++ b/tests
@@ -206,7 +206,7 @@ EOF
 	./safe get secret/random:five; exitok $? 0
 
 	testing $version gen with length flag
-	./safe gen secret/random:six -l 10 
+	./safe gen secret/random:six -l 10
 	./safe get secret/random:six | tr -d '\n' >t/home/got
 	if [[ $(cat t/home/got | wc -m) -ne 10 ]]; then
 	  echo "FAILED"
@@ -281,17 +281,115 @@ EOF
 	./safe delete secret/delete/seven:gobbledegook; exitok $? 0
 	./safe get secret/delete/seven:foo; exitok $? 0
 
+	###### COPY TESTS ######
+
+	testing $version copy a secret to another location
+	./safe set secret/copy/from1 beep=boop
+	./safe copy secret/copy/from1 secret/copy/to1; exitok $? 0
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/copy/from1:beep >t/home/got 2>t/home/errors
+	diffok
+	./safe get secret/copy/to1:beep >t/home/got 2>t/home/errors
+	diffok
+
+
+	testing $version copy a key to another secret without a key specified
+	./safe set secret/copy/from2 beep=boop foo=bar
+	./safe copy secret/copy/from2:beep secret/copy/to2; exitok $? 0
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/copy/from2:beep >t/home/got 2>t/home/errors
+	diffok
+	./safe get secret/copy/to2:beep >t/home/got 2>t/home/errors
+	diffok
+	cat >t/home/want <<EOF
+bar
+EOF
+  ./safe get secret/copy/from2:foo >t/home/got 2>t/home/errors
+	diffok
+	./safe get secret/copy/to2:foo; exitok $? 1
+
+
+	testing $version copy a key to another specified key where the dest secret exists
+	./safe set secret/copy/from3 beep=boop foo=bar
+	./safe set secret/copy/to3 wom=bat
+	./safe copy secret/copy/from3:beep secret/copy/to3:another; exitok $? 0
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/copy/from3:beep >t/home/got 2>t/home/errors
+	diffok
+	./safe get secret/copy/to3:another >t/home/got 2>t/home/errors
+	diffok
+	cat >t/home/want <<EOF
+bar
+EOF
+  ./safe get secret/copy/from3:foo >t/home/got 2>t/home/errors
+	diffok
+	./safe get secret/copy/to3:foo; exitok $? 1
+cat >t/home/want <<EOF
+bat
+EOF
+  ./safe get secret/copy/to3:wom >t/home/got 2>t/home/errors
+	diffok
+
+
+	testing $version copy a key to another specified key where the dest secret does not exist
+	./safe set secret/copy/from4 beep=boop foo=bar
+	./safe copy secret/copy/from4:beep secret/copy/to4:another; exitok $? 0
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/copy/from3:beep >t/home/got 2>t/home/errors
+	diffok
+	./safe get secret/copy/to3:another >t/home/got 2>t/home/errors
+	diffok
+	cat >t/home/want <<EOF
+bar
+EOF
+  ./safe get secret/copy/from3:foo >t/home/got 2>t/home/errors
+	diffok
+	./safe get secret/copy/to3:foo; exitok $? 1
+
+
+	testing $version copying a full secret to a specified key should fail
+	./safe set secret/copy/from5 beep=boop
+	./safe copy secret/copy/from5 secret/copy/to5; exitok $? 0
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/copy/from5:beep >t/home/got 2>t/home/errors
+	diffok
+
+
+	testing $version copying from a secret that does not exist should fail
+	./safe copy secret/copy/from6 secret/copy/to6; exitok $? 1
+
+	echo "beep"
+
+	testing $version copying from a key where the underlying secret does not exist should fail
+	./safe copy secret/copy/from7:beep secret/copy/to7; exitok $? 1
+
+	echo "boop"
+
+	testing $version copying from a missing key where the underlying secret exists should fail
+	./safe set secret/copy/from8 foo=bar
+	./safe copy secret/copy/from8:beep secret/copy/to8; exitok $? 1
+
   ###### TREE TESTS ######
 
 	testing $version tree display
 	./safe gen secret/tree/alpha     x >/dev/null
 	./safe gen secret/tree/g         x >/dev/null
 	./safe gen secret/tree/g/a       x >/dev/null
-	./safe gen secret/tree/beta/name:x >/dev/null
+	./safe gen secret/tree/beta/name x >/dev/null
 	./safe gen secret/tree/beta/env  x >/dev/null
 	./safe gen secret/tree/g/a/m     x >/dev/null
 	./safe gen secret/tree/g/a/m/m   x >/dev/null
-	./safe gen secret/tree/g/a/m/m/a:x >/dev/null
+	./safe gen secret/tree/g/a/m/m/a x >/dev/null
 	./safe tree secret/tree >t/home/got 2>t/home/errors
 	cat >t/home/want <<EOF
 .

--- a/tests
+++ b/tests
@@ -231,47 +231,33 @@ EOF
 
 	testing $version secret deletion
 	./safe set secret/delete/one hello=world
-	./safe delete secret/delete/one
-	exitok $? 0
-	./safe get secret/delete/one
-	exitok $? 1
+	./safe delete secret/delete/one; exitok $? 0
+	./safe get secret/delete/one; exitok $? 1
 
 	testing $version multiple secret deletion
 	./safe set secret/delete/two foo=bar
 	./safe set secret/delete/three wom=bat
-	./safe delete secret/delete/two secret/delete/three
-	exitok $? 0
-	./safe get secret/delete/two
-	exitok $? 1
-	./safe get secret/delete/three
-	exitok $? 1
+	./safe delete secret/delete/two secret/delete/three; exitok $? 0
+	./safe get secret/delete/two; exitok $? 1
+	./safe get secret/delete/three; exitok $? 1
 
 	testing $version key deletion with key remaining within secret afterwards
 	./safe set secret/delete/four foo=bar wom=bat
-	./safe delete secret/delete/four:wom
-	exitok $? 0
-	./safe get secret/delete/four:wom
-	exitok $? 1
-	./safe get secret/delete/four:foo
-	exitok $? 0
+	./safe delete secret/delete/four:wom; exitok $? 0
+	./safe get secret/delete/four:wom; exitok $? 1
+	./safe get secret/delete/four:foo; exitok $? 0
 
 	testing $version key deletion with no keys remaining should delete secret
 	./safe set secret/delete/five foo=bar
-	./safe delete secret/delete/five:foo
-	exitok $? 0
-	./safe get secret/delete/five
-	exitok $? 1
+	./safe delete secret/delete/five:foo; exitok $? 0
+	./safe get secret/delete/five; exitok $? 1
 
 	testing $version multiple key deletion
 	./safe set secret/delete/six foo=bar wom=bat beep=boop
-	./safe delete secret/delete/six:foo secret/delete/six:wom
-	exitok $? 0
-	./safe get secret/delete/six:foo
-	exitok $? 1
-	./safe get secret/delete/six:wom
-	exitok $? 1
-	./safe get secret/delete/six:beep
-	exitok $? 0
+	./safe delete secret/delete/six:foo secret/delete/six:wom; exitok $? 0
+	./safe get secret/delete/six:foo; exitok $? 1
+	./safe get secret/delete/six:wom; exitok $? 1
+	./safe get secret/delete/six:beep; exitok $? 0
 
 	testing $version attempt to delete non-existent key
 	./safe delete secret/delete/gobbledegook; exitok $? 0
@@ -289,10 +275,8 @@ EOF
 	cat >t/home/want <<EOF
 boop
 EOF
-	./safe get secret/copy/from1:beep >t/home/got 2>t/home/errors
-	diffok
-	./safe get secret/copy/to1:beep >t/home/got 2>t/home/errors
-	diffok
+	./safe get secret/copy/from1:beep >t/home/got 2>t/home/errors; diffok
+	./safe get secret/copy/to1:beep >t/home/got 2>t/home/errors; diffok
 
 
 	testing $version copy a key to another secret without a key specified
@@ -301,15 +285,12 @@ EOF
 	cat >t/home/want <<EOF
 boop
 EOF
-	./safe get secret/copy/from2:beep >t/home/got 2>t/home/errors
-	diffok
-	./safe get secret/copy/to2:beep >t/home/got 2>t/home/errors
-	diffok
+	./safe get secret/copy/from2:beep >t/home/got 2>t/home/errors; diffok
+	./safe get secret/copy/to2:beep >t/home/got 2>t/home/errors; diffok
 	cat >t/home/want <<EOF
 bar
 EOF
-  ./safe get secret/copy/from2:foo >t/home/got 2>t/home/errors
-	diffok
+  ./safe get secret/copy/from2:foo >t/home/got 2>t/home/errors; diffok
 	./safe get secret/copy/to2:foo; exitok $? 1
 
 
@@ -320,21 +301,17 @@ EOF
 	cat >t/home/want <<EOF
 boop
 EOF
-	./safe get secret/copy/from3:beep >t/home/got 2>t/home/errors
-	diffok
-	./safe get secret/copy/to3:another >t/home/got 2>t/home/errors
-	diffok
+	./safe get secret/copy/from3:beep >t/home/got 2>t/home/errors; diffok
+	./safe get secret/copy/to3:another >t/home/got 2>t/home/errors; diffok
 	cat >t/home/want <<EOF
 bar
 EOF
-  ./safe get secret/copy/from3:foo >t/home/got 2>t/home/errors
-	diffok
+  ./safe get secret/copy/from3:foo >t/home/got 2>t/home/errors; diffok
 	./safe get secret/copy/to3:foo; exitok $? 1
 cat >t/home/want <<EOF
 bat
 EOF
-  ./safe get secret/copy/to3:wom >t/home/got 2>t/home/errors
-	diffok
+  ./safe get secret/copy/to3:wom >t/home/got 2>t/home/errors; diffok
 
 
 	testing $version copy a key to another specified key where the dest secret does not exist
@@ -343,41 +320,118 @@ EOF
 	cat >t/home/want <<EOF
 boop
 EOF
-	./safe get secret/copy/from3:beep >t/home/got 2>t/home/errors
-	diffok
-	./safe get secret/copy/to3:another >t/home/got 2>t/home/errors
-	diffok
+	./safe get secret/copy/from3:beep >t/home/got 2>t/home/errors; diffok
+	./safe get secret/copy/to3:another >t/home/got 2>t/home/errors; diffok
 	cat >t/home/want <<EOF
 bar
 EOF
-  ./safe get secret/copy/from3:foo >t/home/got 2>t/home/errors
-	diffok
+  ./safe get secret/copy/from3:foo >t/home/got 2>t/home/errors; diffok
 	./safe get secret/copy/to3:foo; exitok $? 1
 
 
 	testing $version copying a full secret to a specified key should fail
 	./safe set secret/copy/from5 beep=boop
-	./safe copy secret/copy/from5 secret/copy/to5; exitok $? 0
+	./safe copy secret/copy/from5 secret/copy/to5:hello; exitok $? 1
 	cat >t/home/want <<EOF
 boop
 EOF
-	./safe get secret/copy/from5:beep >t/home/got 2>t/home/errors
-	diffok
+	./safe get secret/copy/from5:beep >t/home/got 2>t/home/errors; diffok
 
 
 	testing $version copying from a secret that does not exist should fail
 	./safe copy secret/copy/from6 secret/copy/to6; exitok $? 1
 
-	echo "beep"
 
 	testing $version copying from a key where the underlying secret does not exist should fail
 	./safe copy secret/copy/from7:beep secret/copy/to7; exitok $? 1
 
-	echo "boop"
 
 	testing $version copying from a missing key where the underlying secret exists should fail
 	./safe set secret/copy/from8 foo=bar
 	./safe copy secret/copy/from8:beep secret/copy/to8; exitok $? 1
+
+	###### MOVE TESTS ######
+
+	testing $version move a secret to another location
+	./safe set secret/move/from1 beep=boop
+	./safe move secret/move/from1 secret/move/to1; exitok $? 0
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/move/from1:beep; exitok $? 1
+	./safe get secret/move/to1:beep >t/home/got 2>t/home/errors; diffok
+
+
+	testing $version move a key to another secret without a key specified
+	./safe set secret/move/from2 beep=boop foo=bar
+	./safe move secret/move/from2:beep secret/move/to2; exitok $? 0
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/move/from2:beep; exitok $? 1
+	./safe get secret/move/to2:beep >t/home/got 2>t/home/errors; diffok
+	cat >t/home/want <<EOF
+bar
+EOF
+  ./safe get secret/move/from2:foo >t/home/got 2>t/home/errors; diffok
+	./safe get secret/move/to2:foo; exitok $? 1
+
+
+	testing $version move a key to another specified key where the dest secret exists
+	./safe set secret/move/from3 beep=boop foo=bar
+	./safe set secret/move/to3 wom=bat
+	./safe move secret/move/from3:beep secret/move/to3:another; exitok $? 0
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/move/from3:beep; exitok $? 1
+	./safe get secret/move/to3:another >t/home/got 2>t/home/errors; diffok
+	cat >t/home/want <<EOF
+bar
+EOF
+  ./safe get secret/move/from3:foo >t/home/got 2>t/home/errors; diffok
+	./safe get secret/move/to3:foo; exitok $? 1
+cat >t/home/want <<EOF
+bat
+EOF
+  ./safe get secret/move/to3:wom >t/home/got 2>t/home/errors; diffok
+
+
+	testing $version move a key to another specified key where the dest secret does not exist
+	./safe set secret/move/from4 beep=boop foo=bar
+	./safe move secret/move/from4:beep secret/move/to4:another; exitok $? 0
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/move/from3:beep; exitok $? 1
+	./safe get secret/move/to3:another >t/home/got 2>t/home/errors; diffok
+	cat >t/home/want <<EOF
+bar
+EOF
+  ./safe get secret/move/from3:foo >t/home/got 2>t/home/errors; diffok
+	./safe get secret/move/to3:foo; exitok $? 1
+
+
+	testing $version moving a full secret to a specified key should fail
+	./safe set secret/move/from5 beep=boop
+	./safe move secret/move/from5 secret/move/to5:beep; exitok $? 1
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/move/from5:beep >t/home/got 2>t/home/errors; diffok
+
+
+	testing $version moving from a secret that does not exist should fail
+	./safe move secret/copy/from6 secret/move/to6; exitok $? 1
+
+
+	testing $version moving from a key where the underlying secret does not exist should fail
+	./safe move secret/move/from7:beep secret/move/to7; exitok $? 1
+
+
+	testing $version moving from a missing key where the underlying secret exists should fail
+	./safe set secret/move/from8 foo=bar
+	./safe move secret/move/from8:beep secret/move/to8; exitok $? 1
 
   ###### TREE TESTS ######
 

--- a/tests
+++ b/tests
@@ -215,6 +215,12 @@ EOF
 		echo "Got $(cat t/home/got | wc -m) instead"
   fi
 
+	testing $version gen with incorrectly mixed path:key should fail
+	./safe gen secret/random secret/random:seven; exitok $? 1
+
+	testing $version gen with missing key should fail
+	./safe gen secret/random; exitok $?
+
 	testing $version single-value retrieval
 	./safe set secret/single/value foo=bar baz=quux >/dev/null
 	foo=$(./safe get secret/single/value:foo)

--- a/tests
+++ b/tests
@@ -281,6 +281,48 @@ EOF
 	./safe delete secret/delete/eight:gobbledegook -f; exitok $? 0
 	./safe get secret/delete/seven:foo; exitok $? 0
 
+	testing $version recursively delete a subtree
+	./safe set secret/delete/subtree1/one foo=bar
+	./safe set secret/delete/subtree1/two beep=boop
+	./safe delete -Rf secret/delete/subtree1; exitok $? 0
+	./safe get secret/delete/subtree1/one; exitok $? 1
+	./safe get secret/delete/subtree1/two; exitok $? 1
+
+	testing $version attempting to delete a subtree without -R should fail
+	./safe set secret/delete/subtree2/one foo=bar
+	./safe set secret/delete/subtree2/two foo=bar
+	./safe delete -f secret/delete/subtree2; exitok $? 1
+	cat >t/home/want <<EOF
+bar
+EOF
+	./safe get secret/delete/subtree2/one:foo >t/home/got 2>t/home/errors; diffok
+	./safe get secret/delete/subtree2/two:foo >t/home/got 2>t/home/errors; diffok
+
+	testing $version recursively delete a leaf node secret
+	./safe set secret/delete/nine foo=bar
+	./safe delete -Rf secret/delete/nine; exitok $? 0
+	./safe get secret/delete/nine; exitok $? 1
+
+	testing $version recursively delete a key
+	./safe set secret/delete/ten foo=bar beep=boop
+	./safe delete -Rf secret/delete/ten:foo
+	./safe get secret/delete/ten:foo; exitok $? 1
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/delete/ten:beep >t/home/got t/home/errors; diffok
+
+	testing $version recursively delete a secret that does not exist with -f should not fail
+	./safe delete -Rf secret/delete/gobbledegook; exitok $? 0
+
+	testing $version recursively delete a key that does not exist with -f should not fail
+	./safe set secret/delete/eleven beep=boop
+	./safe delete -Rf secret/delete/eleven:foo; exitok $? 0
+	cat >t/home/want <<EOF
+boop
+EOF
+	./safe get secret/delete/eleven:beep >t/home/got 2>t/home/errors; diffok
+
 	###### COPY TESTS ######
 
 	testing $version copy a secret to another location

--- a/tests
+++ b/tests
@@ -192,6 +192,29 @@ EOF
 		echo "              to only contain: [1-9]"
 	fi
 
+	testing $version password with secret:key syntax
+	./safe gen 64 secret/random:two
+	exitok $? 0
+	./safe get secret/random:two
+	exitok $? 0
+
+	testing $version gen with multiple passwords to make
+	./safe gen 64 secret/random:three secret/random four secret/random:five
+	exitok $? 0
+	./safe get secret/random:three; exitok $? 0
+	./safe get secret/random:four; exitok $? 0
+	./safe get secret/random:five; exitok $? 0
+
+	testing $version gen with length flag
+	./safe gen secret/random:six -l 10 
+	./safe get secret/random:six | tr -d '\n' >t/home/got
+	if [[ $(cat t/home/got | wc -m) -ne 10 ]]; then
+	  echo "FAILED"
+		rc=1
+		echo "Expected generated password to have 10 characters"
+		echo "Got $(cat t/home/got | wc -m) instead"
+  fi
+
 	testing $version single-value retrieval
 	./safe set secret/single/value foo=bar baz=quux >/dev/null
 	foo=$(./safe get secret/single/value:foo)
@@ -208,11 +231,11 @@ EOF
 	./safe gen secret/tree/alpha     x >/dev/null
 	./safe gen secret/tree/g         x >/dev/null
 	./safe gen secret/tree/g/a       x >/dev/null
-	./safe gen secret/tree/beta/name x >/dev/null
+	./safe gen secret/tree/beta/name:x >/dev/null
 	./safe gen secret/tree/beta/env  x >/dev/null
 	./safe gen secret/tree/g/a/m     x >/dev/null
 	./safe gen secret/tree/g/a/m/m   x >/dev/null
-	./safe gen secret/tree/g/a/m/m/a x >/dev/null
+	./safe gen secret/tree/g/a/m/m/a:x >/dev/null
 	./safe tree secret/tree >t/home/got 2>t/home/errors
 	cat >t/home/want <<EOF
 .

--- a/tests
+++ b/tests
@@ -227,6 +227,62 @@ EOF
 		echo "ok"
 	fi
 
+	###### DELETION TESTS ######
+
+	testing $version secret deletion
+	./safe set secret/delete/one hello=world
+	./safe delete secret/delete/one
+	exitok $? 0
+	./safe get secret/delete/one
+	exitok $? 1
+
+	testing $version multiple secret deletion
+	./safe set secret/delete/two foo=bar
+	./safe set secret/delete/three wom=bat
+	./safe delete secret/delete/two secret/delete/three
+	exitok $? 0
+	./safe get secret/delete/two
+	exitok $? 1
+	./safe get secret/delete/three
+	exitok $? 1
+
+	testing $version key deletion with key remaining within secret afterwards
+	./safe set secret/delete/four foo=bar wom=bat
+	./safe delete secret/delete/four:wom
+	exitok $? 0
+	./safe get secret/delete/four:wom
+	exitok $? 1
+	./safe get secret/delete/four:foo
+	exitok $? 0
+
+	testing $version key deletion with no keys remaining should delete secret
+	./safe set secret/delete/five foo=bar
+	./safe delete secret/delete/five:foo
+	exitok $? 0
+	./safe get secret/delete/five
+	exitok $? 1
+
+	testing $version multiple key deletion
+	./safe set secret/delete/six foo=bar wom=bat beep=boop
+	./safe delete secret/delete/six:foo secret/delete/six:wom
+	exitok $? 0
+	./safe get secret/delete/six:foo
+	exitok $? 1
+	./safe get secret/delete/six:wom
+	exitok $? 1
+	./safe get secret/delete/six:beep
+	exitok $? 0
+
+	testing $version attempt to delete non-existent key
+	./safe delete secret/delete/gobbledegook; exitok $? 0
+
+	testing $version attempt to delete non-existing key within existing secret should not error
+	./safe set secret/delete/seven foo=bar
+	./safe delete secret/delete/seven:gobbledegook; exitok $? 0
+	./safe get secret/delete/seven:foo; exitok $? 0
+
+  ###### TREE TESTS ######
+
 	testing $version tree display
 	./safe gen secret/tree/alpha     x >/dev/null
 	./safe gen secret/tree/g         x >/dev/null

--- a/tests
+++ b/tests
@@ -216,10 +216,10 @@ EOF
   fi
 
 	testing $version gen with incorrectly mixed path:key should fail
-	./safe gen secret/random secret/random:seven; exitok $? 1
+	./safe gen secret/random secret/random:seven 2>/dev/null; exitok $? 1
 
 	testing $version gen with missing key should fail
-	./safe gen secret/random; exitok $?
+	./safe gen secret/random 2>/dev/null; exitok $? 1
 
 	testing $version single-value retrieval
 	./safe set secret/single/value foo=bar baz=quux >/dev/null
@@ -233,7 +233,7 @@ EOF
 		echo "ok"
 	fi
 
-	###### DELETION TESTS ######
+	###### DELETE TESTS ######
 
 	testing $version secret deletion
 	./safe set secret/delete/one hello=world
@@ -265,12 +265,20 @@ EOF
 	./safe get secret/delete/six:wom; exitok $? 1
 	./safe get secret/delete/six:beep; exitok $? 0
 
-	testing $version attempt to delete non-existent key
-	./safe delete secret/delete/gobbledegook; exitok $? 0
+	testing $version attempt to delete non-existent key should fail
+	./safe delete secret/delete/gobbledegook; exitok $? 1
 
-	testing $version attempt to delete non-existing key within existing secret should not error
+	testing $version attempt to delete non-existing key within existing secret should error
 	./safe set secret/delete/seven foo=bar
-	./safe delete secret/delete/seven:gobbledegook; exitok $? 0
+	./safe delete secret/delete/seven:gobbledegook; exitok $? 1
+	./safe get secret/delete/seven:foo; exitok $? 0
+
+	testing $version delete non-existent key should not fail if -f is given
+	./safe delete secret/delete/gobbledegook -f; exitok $? 0
+
+	testing $version attempt to delete non-existing key within existing secret should error
+	./safe set secret/delete/eight foo=bar
+	./safe delete secret/delete/eight:gobbledegook -f; exitok $? 0
 	./safe get secret/delete/seven:foo; exitok $? 0
 
 	###### COPY TESTS ######

--- a/ui.go
+++ b/ui.go
@@ -10,6 +10,10 @@ import (
 	"github.com/starkandwayne/safe/prompt"
 )
 
+func warn(warning string, args ...interface{}) {
+	ansi.Fprintf(os.Stderr, "warning: @Y{%s}\n", fmt.Sprintf(warning, args...))
+}
+
 func fail(err error) {
 	if err != nil {
 		ansi.Fprintf(os.Stderr, "failed: @R{%s}\n", err)

--- a/vault/errors.go
+++ b/vault/errors.go
@@ -22,7 +22,7 @@ func (e keyNotFound) Error() string {
 //IsNotFound returns true if the given error is a SecretNotFound error
 // 	or a KeyNotFound error. Returns false otherwise.
 func IsNotFound(err error) bool {
-	return isSecretNotFound(err) || isKeyNotFound(err)
+	return IsSecretNotFound(err) || IsKeyNotFound(err)
 }
 
 //NewSecretNotFoundError returns an error with a message descibing the path
@@ -31,7 +31,9 @@ func NewSecretNotFoundError(path string) error {
 	return secretNotFound{path}
 }
 
-func isSecretNotFound(err error) bool {
+//IsSecretNotFound returns true if the given error was created with
+// NewSecretNotFoundError().  False otherwise.
+func IsSecretNotFound(err error) bool {
 	_, is := err.(secretNotFound)
 	return is
 }
@@ -44,7 +46,9 @@ func NewKeyNotFoundError(path, key string) error {
 	return keyNotFound{secret: path, key: key}
 }
 
-func isKeyNotFound(err error) bool {
+//IsKeyNotFound returns true if the given error was created with
+// NewKeyNotFoundError(). False otherwise.
+func IsKeyNotFound(err error) bool {
 	_, is := err.(keyNotFound)
 	return is
 }

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -54,6 +54,12 @@ func (s *Secret) Delete(key string) bool {
 	return true
 }
 
+// Empty returns true if there are no key-value pairs in this Secret object.
+// False otherwise.
+func (s *Secret) Empty() bool {
+	return len(s.data) == 0
+}
+
 func (s *Secret) Format(oldKey, newKey, fmtType string) error {
 	if !s.Has(oldKey) {
 		return NewSecretNotFoundError(oldKey)

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -44,6 +44,16 @@ func (s *Secret) Set(key, value string) {
 	s.data[key] = value
 }
 
+// Delete removes the entry with the given key from the Secret.
+// Returns true if there was a matching object to delete. False otherwise.
+func (s *Secret) Delete(key string) bool {
+	if !s.Has(key) {
+		return false
+	}
+	delete(s.data, key)
+	return true
+}
+
 func (s *Secret) Format(oldKey, newKey, fmtType string) error {
 	if !s.Has(oldKey) {
 		return NewSecretNotFoundError(oldKey)

--- a/vault/secret_test.go
+++ b/vault/secret_test.go
@@ -29,3 +29,26 @@ func TestSingleValue(t *testing.T) {
 		}
 	}
 }
+
+func TestNewSecretIsEmpty(t *testing.T) {
+	if !NewSecret().Empty() {
+		t.Errorf("New secret is not considered empty")
+	}
+}
+
+func TestPopulatedSecretIsNotEmpty(t *testing.T) {
+	s := NewSecret()
+	s.Set("beep", "boop")
+	if s.Empty() {
+		t.Errorf("Secret with contents was considered empty")
+	}
+}
+
+func TestDeletedKeysCanEmptySecret(t *testing.T) {
+	s := NewSecret()
+	s.Set("beep", "boop")
+	s.Delete("beep")
+	if !s.Empty() {
+		t.Errorf("Secret with all keys deleted was not considered to be empty")
+	}
+}

--- a/vault/utils.go
+++ b/vault/utils.go
@@ -12,3 +12,10 @@ func ParsePath(path string) (secret, key string) {
 	}
 	return
 }
+
+// PathHasKey returns true if the given path has a key specified in its syntax.
+// False otherwise.
+func PathHasKey(path string) bool {
+	_, key := ParsePath(path)
+	return key != ""
+}


### PR DESCRIPTION
* Fixes #75 
* delete, move, copy, and gen have been updated to accept secret:key syntax 
* Gen can now accept multiple path arguments to make multiple passwords with a single command.
* Gen now has a `-l` flag to set password length. This takes priority over the existing location-based syntax, but does not conflict with it. At a later time, we may want to deprecate the old syntax.
* Tests for all the things.