### PR TITLE
    Add --noclobber support to safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ release
 ci/credentials.yml
 /t
 /vaults
+*.swp

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,7 +1,7 @@
 # New Features
 
 
-- New global flag `--noclobber` will throw a message up to the user
+- New global flag `--no-clobber` will throw a message up to the user
   that they tried to overwrite an existing credential.
   This is supported in all known write-causing commands,
   except `safe import`.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,13 @@
+# New Features
+
+
+- New global flag `--noclobber` will throw a message up to the user
+  that they tried to overwrite an existing credential.
+  This is supported in all known write-causing commands,
+  except `safe import`.
+
+  When existing credentials are encountered, safe will exit 0,
+  as it successfully avoided clobbering the credential.
+
+  `--quiet` can be provided to suppress the clobber-noop warning
+  messages

--- a/main.go
+++ b/main.go
@@ -588,7 +588,6 @@ are omitted. Unlike the 'safe set' and 'safe paste' commands, data entry
 is NOT obscured.
 `,
 	}, func(command string, args ...string) error {
-		//writeHelper is defined right above this subcommand
 		return writeHelper(false, false, "ask", args...)
 	})
 
@@ -607,7 +606,6 @@ you don't want the value to show up in your ~/.bash_history, or in the
 process table.
 `,
 	}, func(command string, args ...string) error {
-		//writeHelper is defined right above the ask subcommand
 		return writeHelper(true, true, "set", args...)
 	})
 
@@ -626,7 +624,6 @@ sense when you are pasting in credentials from an external password manager
 like 1password or Lastpass.
 `,
 	}, func(command string, args ...string) error {
-		//writeHelper is defined right above the ask subcommand
 		//Dispatch call.
 		return writeHelper(false, true, "paste", args...)
 	})
@@ -1096,7 +1093,7 @@ NBITS defaults to 2048.
 		exists := (err == nil)
 		if opt.SkipIfExists && exists && s.Has("dhparam-pem") {
 			if !opt.Quiet {
-				ansi.Fprintf(os.Stderr, "@R{Cowardly refusing to generate a DH Param in} @C{%s} @R{as it is already present in Vault}\n", path)
+				ansi.Fprintf(os.Stderr, "@R{Cowardly refusing to generate a Diffie-Hellman key exchange parameters in} @C{%s} @R{as it is already present in Vault}\n", path)
 			}
 			return nil
 		}
@@ -1112,7 +1109,7 @@ NBITS defaults to 2048.
 		Type:    NonDestructiveCommand,
 	}, func(command string, args ...string) error {
 		// --no-clobber is ignored here, because there's no context of what you're
-		// about to be writing after a prompt, so not sure if we should our shouldn't prompt
+		// about to be writing after a prompt, so not sure if we should or shouldn't prompt
 		// if you need to write something and prompt, but only if it isnt already present
 		// in vault, see the `ask` subcommand
 		fmt.Fprintf(os.Stderr, "%s\n", strings.Join(args, " "))

--- a/main.go
+++ b/main.go
@@ -53,7 +53,8 @@ type Options struct {
 	Insecure     bool `cli:"-k, --insecure"`
 	Version      bool `cli:"-v, --version"`
 	Help         bool `cli:"-h, --help"`
-	SkipIfExists bool `cli:"--noclobber"`
+	Clobber      bool `cli:"--clobber, --no-clobber"`
+	SkipIfExists bool
 	Quiet        bool `cli:"--quiet"`
 
 	HelpCommand    struct{} `cli:"help"`
@@ -184,6 +185,8 @@ func main() {
 	opt.Cert.Role = "default"
 	opt.Cert.Backend = "pki"
 	opt.Revoke.Backend = "pki"
+
+	opt.Clobber = true
 
 	opt.X509.Issue.Bits = 4096
 	opt.X509.Issue.TTL = "10y"
@@ -1911,6 +1914,8 @@ Currently, only the --renew option is supported, and it is required:
 	}
 
 	for p.Next() {
+		opt.SkipIfExists = !opt.Clobber
+
 		if opt.Version {
 			r.Execute("version")
 			return

--- a/tests
+++ b/tests
@@ -589,6 +589,9 @@ EOF
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to update secret/existing/gen:val as it is already present in Vault
 EOF
+	./safe --quiet --noclobber gen secret/existing/gen val >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
 	./safe get secret/existing/gen >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 $expected
@@ -606,6 +609,10 @@ EOF
 	cat >t/home/want <<EOF ; diffok
 val: test2
 Cowardly refusing to update secret/existing/set, as the following keys would be clobbered: val
+EOF
+	./safe --quiet --noclobber set secret/existing/set val=test2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+val: test2
 EOF
 	./safe get secret/existing/set >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -625,6 +632,10 @@ EOF
 val: test2
 Cowardly refusing to update secret/existing/paste, as the following keys would be clobbered: val
 EOF
+	./safe --quiet --noclobber paste secret/existing/paste val=test2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+val: test2
+EOF
 	./safe get secret/existing/paste >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 $expected
@@ -642,6 +653,10 @@ EOF
 	cat >t/home/want <<EOF ; diffok
 val: test2
 Cowardly refusing to update secret/existing/ask, as the following keys would be clobbered: val
+EOF
+	./safe --quiet --noclobber ask secret/existing/ask val=test2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+val: test2
 EOF
 	./safe get secret/existing/ask >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -661,7 +676,7 @@ EOF
 
 	testing $version --noclobber move functionality without existing data
 	./safe set secret/existing/to-move key=val
-	./safe --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	expected=$(./safe get secret/move-existing)
@@ -670,6 +685,10 @@ EOF
 	./safe --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to copy/move data into secret/move-existing, as it would clobber existing data
+EOF
+	./safe set secret/existing/to-move key=val2
+	./safe --quiet --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/move-existing >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -688,6 +707,10 @@ EOF
 	./safe --noclobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to copy/move data into secret/existing/key-move:key2, as it would clobber existing data
+EOF
+	./safe set secret/existing/key-move key=val2
+	./safe --quiet --noclobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/existing/key-move >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -710,6 +733,12 @@ EOF
 Cowardly refusing to copy/move data into secret/move-recursive-existing, as the following paths would be clobbered:
 - secret/move-recursive-existing/first
 - secret/move-recursive-existing/second
+EOF
+	./safe set secret/move-recursive/first key=val2
+	./safe set secret/move-recursive/second key=val2
+	./safe set secret/move-recursive/third key=val2
+	./safe --quiet --noclobber move -Rf secret/move-recursive secret/move-recursive-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe tree secret/move-recursive-existing >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -771,6 +800,10 @@ EOF
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to copy/move data into secret/copy-existing, as it would clobber existing data
 EOF
+	./safe set secret/existing/to-copy key=val2
+	./safe --quiet --noclobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
 	./safe get secret/copy-existing >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 $expected
@@ -792,6 +825,12 @@ EOF
 Cowardly refusing to copy/move data into secret/copy-recursive-existing, as the following paths would be clobbered:
 - secret/copy-recursive-existing/first
 - secret/copy-recursive-existing/second
+EOF
+	./safe set secret/copy-recursive/first key=val2
+	./safe set secret/copy-recursive/second key=val2
+	./safe set secret/copy-recursive/third key=val2
+	./safe --quiet --noclobber copy -Rf secret/copy-recursive secret/copy-recursive-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe tree secret/copy-recursive-existing >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -824,6 +863,9 @@ EOF
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to generate an SSH key at secret/existing/ssh as it is already present in Vault
 EOF
+	./safe --quiet --noclobber ssh secret/existing/ssh >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
 	./safe get secret/existing/ssh >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 $expected
@@ -840,6 +882,9 @@ EOF
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to generate an RSA key at secret/existing/rsa as it is already present in Vault
 EOF
+	./safe --quiet --noclobber rsa secret/existing/rsa >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
 	./safe get secret/existing/rsa >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 $expected
@@ -855,6 +900,9 @@ EOF
 	./safe --noclobber dhparam secret/existing/dhparam >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to generate a DH Param in secret/existing/dhparam as it is already present in Vault
+EOF
+	./safe --quiet --noclobber dhparam secret/existing/dhparam >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/existing/dhparam >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -874,6 +922,9 @@ EOF
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to reformat secret/existing/to-fmt:val to crypted as it is already present in Vault
 EOF
+	./safe --quiet --noclobber fmt crypt-sha512 secret/existing/to-fmt val crypted >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
 	./safe get secret/existing/to-fmt:crypted >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 $expected
@@ -888,6 +939,9 @@ EOF
 	./safe --noclobber x509 issue --ca --name test secret/existing/cert >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to create a new certificate in secret/existing/cert as it is already present in Vault
+EOF
+	./safe --quiet --noclobber x509 issue --ca --name test secret/existing/cert >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/existing/cert >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -905,6 +959,7 @@ EOF
 EOF
 	testing $version --noclobber recursive delete functionality
 	./safe --noclobber set secret/existing/to-delete key=val
+	./safe --noclobber set secret/existing/to-delete/subkey key=val
 	./safe --noclobber delete -Rf secret/existing/to-delete >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF

--- a/tests
+++ b/tests
@@ -619,6 +619,19 @@ EOF
 $expected
 
 EOF
+	testing $version --noclobber set functionality with different key in same path 
+	./safe --noclobber set secret/existing/set2 val=test; exitok $? 0
+	./safe --noclobber set secret/existing/set2 val2=test2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+val2: test2
+EOF
+	./safe --noclobber get secret/existing/set2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+--- # secret/existing/set2
+val: test
+val2: test2
+
+EOF
 
 	testing $version --noclobber paste functionality without existing data
 	./safe --noclobber paste secret/existing/paste val=test >t/home/got 2>&1; exitok $? 0
@@ -684,7 +697,7 @@ EOF
 	./safe set secret/existing/to-move key=val2
 	./safe --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
-Cowardly refusing to copy/move data into secret/move-existing, as it would clobber existing data
+Cowardly refusing to copy/move data into secret/move-existing, as that would clobber existing data
 EOF
 	./safe set secret/existing/to-move key=val2
 	./safe --quiet --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
@@ -706,7 +719,7 @@ EOF
 	./safe set secret/existing/key-move key=val2
 	./safe --noclobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
-Cowardly refusing to copy/move data into secret/existing/key-move:key2, as it would clobber existing data
+Cowardly refusing to copy/move data into secret/existing/key-move:key2, as that would clobber existing data
 EOF
 	./safe set secret/existing/key-move key=val2
 	./safe --quiet --noclobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
@@ -798,7 +811,7 @@ EOF
 	./safe set secret/existing/to-copy key=val2
 	./safe --noclobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
-Cowardly refusing to copy/move data into secret/copy-existing, as it would clobber existing data
+Cowardly refusing to copy/move data into secret/copy-existing, as that would clobber existing data
 EOF
 	./safe set secret/existing/to-copy key=val2
 	./safe --quiet --noclobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
@@ -899,7 +912,7 @@ EOF
 	testing $version --noclobber dhparam functionality with existing data
 	./safe --noclobber dhparam secret/existing/dhparam >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
-Cowardly refusing to generate a DH Param in secret/existing/dhparam as it is already present in Vault
+Cowardly refusing to generate a Diffie-Hellman key exchange parameters in secret/existing/dhparam as it is already present in Vault
 EOF
 	./safe --quiet --noclobber dhparam secret/existing/dhparam >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok

--- a/tests
+++ b/tests
@@ -578,18 +578,18 @@ bar
 EOF
 	./safe get secret/move/from11:foo >t/home/got 2>t/home/errors; diffok
 
-  ###### --noclobber TESTS #####
-	testing $version --noclobber gen functionality without existing data
-	./safe --noclobber gen secret/existing/gen val >t/home/got 2>&1; exitok $? 0
+  ###### --no-clobber TESTS #####
+	testing $version --no-clobber gen functionality without existing data
+	./safe --no-clobber gen secret/existing/gen val >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	expected=$(./safe get secret/existing/gen)
-	testing $version --noclobber gen functionality with existing data
-	./safe --noclobber gen secret/existing/gen val >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber gen functionality with existing data
+	./safe --no-clobber gen secret/existing/gen val >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to update secret/existing/gen:val as it is already present in Vault
 EOF
-	./safe --quiet --noclobber gen secret/existing/gen val >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber gen secret/existing/gen val >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/existing/gen >t/home/got; exitok $? 0
@@ -598,19 +598,19 @@ $expected
 
 EOF
 
-	testing $version --noclobber set functionality without existing data
-	./safe --noclobber set secret/existing/set val=test >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber set functionality without existing data
+	./safe --no-clobber set secret/existing/set val=test >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 val: test
 EOF
 	expected=$(./safe get secret/existing/set)
-	testing $version --noclobber set functionality with existing data
-	./safe --noclobber set secret/existing/set val=test2 >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber set functionality with existing data
+	./safe --no-clobber set secret/existing/set val=test2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 val: test2
 Cowardly refusing to update secret/existing/set, as the following keys would be clobbered: val
 EOF
-	./safe --quiet --noclobber set secret/existing/set val=test2 >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber set secret/existing/set val=test2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 val: test2
 EOF
@@ -619,13 +619,13 @@ EOF
 $expected
 
 EOF
-	testing $version --noclobber set functionality with different key in same path 
-	./safe --noclobber set secret/existing/set2 val=test; exitok $? 0
-	./safe --noclobber set secret/existing/set2 val2=test2 >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber set functionality with different key in same path 
+	./safe --no-clobber set secret/existing/set2 val=test; exitok $? 0
+	./safe --no-clobber set secret/existing/set2 val2=test2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 val2: test2
 EOF
-	./safe --noclobber get secret/existing/set2 >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber get secret/existing/set2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 --- # secret/existing/set2
 val: test
@@ -633,19 +633,19 @@ val2: test2
 
 EOF
 
-	testing $version --noclobber paste functionality without existing data
-	./safe --noclobber paste secret/existing/paste val=test >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber paste functionality without existing data
+	./safe --no-clobber paste secret/existing/paste val=test >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 val: test
 EOF
 	expected=$(./safe get secret/existing/paste)
-	testing $version --noclobber paste functionality with existing data
-	./safe --noclobber paste secret/existing/paste val=test2 >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber paste functionality with existing data
+	./safe --no-clobber paste secret/existing/paste val=test2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 val: test2
 Cowardly refusing to update secret/existing/paste, as the following keys would be clobbered: val
 EOF
-	./safe --quiet --noclobber paste secret/existing/paste val=test2 >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber paste secret/existing/paste val=test2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 val: test2
 EOF
@@ -655,19 +655,19 @@ $expected
 
 EOF
 
-	testing $version --noclobber ask functionality without existing data
-	./safe --noclobber ask secret/existing/ask val=test >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber ask functionality without existing data
+	./safe --no-clobber ask secret/existing/ask val=test >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 val: test
 EOF
 	expected=$(./safe get secret/existing/ask)
-	testing $version --noclobber ask functionality with existing data
-	./safe --noclobber ask secret/existing/ask val=test2 >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber ask functionality with existing data
+	./safe --no-clobber ask secret/existing/ask val=test2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 val: test2
 Cowardly refusing to update secret/existing/ask, as the following keys would be clobbered: val
 EOF
-	./safe --quiet --noclobber ask secret/existing/ask val=test2 >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber ask secret/existing/ask val=test2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 val: test2
 EOF
@@ -677,8 +677,8 @@ $expected
 
 EOF
 
-	testing $version --noclobber import functionality
-	./safe --noclobber import secret/existing/import <<EOF >t/home/got 2>&1; exitok $? 1
+	testing $version --no-clobber import functionality
+	./safe --no-clobber import secret/existing/import <<EOF >t/home/got 2>&1; exitok $? 1
 {"secret/existing/import":{"should": "not import"}}
 EOF
 	cat >t/home/want <<EOF ; diffok
@@ -687,20 +687,20 @@ safe import - Import name/value pairs into the current Vault
 USAGE: safe import <backup/file.json
 EOF
 
-	testing $version --noclobber move functionality without existing data
+	testing $version --no-clobber move functionality without existing data
 	./safe set secret/existing/to-move key=val
-	./safe --quiet --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	expected=$(./safe get secret/move-existing)
-	testing $version --noclobber move functionality with existing data
+	testing $version --no-clobber move functionality with existing data
 	./safe set secret/existing/to-move key=val2
-	./safe --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to copy/move data into secret/move-existing, as that would clobber existing data
 EOF
 	./safe set secret/existing/to-move key=val2
-	./safe --quiet --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/move-existing >t/home/got; exitok $? 0
@@ -709,20 +709,20 @@ $expected
 
 EOF
 
-	testing $version --noclobber move to key functionality without existing data
+	testing $version --no-clobber move to key functionality without existing data
 	./safe set secret/existing/key-move key=val
-	./safe --noclobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	expected=$(./safe get secret/existing/key-move)
-	testing $version --noclobber move to key functionality with existing data
+	testing $version --no-clobber move to key functionality with existing data
 	./safe set secret/existing/key-move key=val2
-	./safe --noclobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to copy/move data into secret/existing/key-move:key2, as that would clobber existing data
 EOF
 	./safe set secret/existing/key-move key=val2
-	./safe --quiet --noclobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/existing/key-move >t/home/got; exitok $? 0
@@ -731,17 +731,17 @@ $expected
 
 EOF
 
-	testing $version --noclobber recursive move functionality without existing data
+	testing $version --no-clobber recursive move functionality without existing data
 	./safe set secret/move-recursive/first key=val
 	./safe set secret/move-recursive/second key=val
-	./safe --noclobber move -Rf secret/move-recursive secret/move-recursive-existing >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber move -Rf secret/move-recursive secret/move-recursive-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
-	testing $version --noclobber recursive move functionality with existing data
+	testing $version --no-clobber recursive move functionality with existing data
 	./safe set secret/move-recursive/first key=val2
 	./safe set secret/move-recursive/second key=val2
 	./safe set secret/move-recursive/third key=val2
-	./safe --noclobber move -Rf secret/move-recursive secret/move-recursive-existing >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber move -Rf secret/move-recursive secret/move-recursive-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to copy/move data into secret/move-recursive-existing, as the following paths would be clobbered:
 - secret/move-recursive-existing/first
@@ -750,7 +750,7 @@ EOF
 	./safe set secret/move-recursive/first key=val2
 	./safe set secret/move-recursive/second key=val2
 	./safe set secret/move-recursive/third key=val2
-	./safe --quiet --noclobber move -Rf secret/move-recursive secret/move-recursive-existing >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber move -Rf secret/move-recursive secret/move-recursive-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe tree secret/move-recursive-existing >t/home/got; exitok $? 0
@@ -801,20 +801,20 @@ key: val2
 
 EOF
 
-	testing $version --noclobber copy functionality without existing data
+	testing $version --no-clobber copy functionality without existing data
 	./safe set secret/existing/to-copy key=val
-	./safe --noclobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	expected=$(./safe get secret/copy-existing)
-	testing $version --noclobber copy functionality with existing data
+	testing $version --no-clobber copy functionality with existing data
 	./safe set secret/existing/to-copy key=val2
-	./safe --noclobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to copy/move data into secret/copy-existing, as that would clobber existing data
 EOF
 	./safe set secret/existing/to-copy key=val2
-	./safe --quiet --noclobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/copy-existing >t/home/got; exitok $? 0
@@ -823,17 +823,17 @@ $expected
 
 EOF
 
-	testing $version --noclobber recurive copy functionality without existing data
+	testing $version --no-clobber recurive copy functionality without existing data
 	./safe set secret/copy-recursive/first key=val
 	./safe set secret/copy-recursive/second key=val
-	./safe --noclobber copy -Rf secret/copy-recursive secret/copy-recursive-existing >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber copy -Rf secret/copy-recursive secret/copy-recursive-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
-	testing $version --noclobber recursive copy functionality with existing data
+	testing $version --no-clobber recursive copy functionality with existing data
 	./safe set secret/copy-recursive/first key=val2
 	./safe set secret/copy-recursive/second key=val2
 	./safe set secret/copy-recursive/third key=val2
-	./safe --noclobber copy -Rf secret/copy-recursive secret/copy-recursive-existing >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber copy -Rf secret/copy-recursive secret/copy-recursive-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to copy/move data into secret/copy-recursive-existing, as the following paths would be clobbered:
 - secret/copy-recursive-existing/first
@@ -842,7 +842,7 @@ EOF
 	./safe set secret/copy-recursive/first key=val2
 	./safe set secret/copy-recursive/second key=val2
 	./safe set secret/copy-recursive/third key=val2
-	./safe --quiet --noclobber copy -Rf secret/copy-recursive secret/copy-recursive-existing >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber copy -Rf secret/copy-recursive secret/copy-recursive-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe tree secret/copy-recursive-existing >t/home/got; exitok $? 0
@@ -866,17 +866,17 @@ key: val
 
 EOF
 
-	testing $version --noclobber ssh functionality without existing data
-	./safe --noclobber ssh secret/existing/ssh >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber ssh functionality without existing data
+	./safe --no-clobber ssh secret/existing/ssh >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	expected=$(./safe get secret/existing/ssh)
-	testing $version --noclobber ssh functionality with existing data
-	./safe --noclobber ssh secret/existing/ssh >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber ssh functionality with existing data
+	./safe --no-clobber ssh secret/existing/ssh >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to generate an SSH key at secret/existing/ssh as it is already present in Vault
 EOF
-	./safe --quiet --noclobber ssh secret/existing/ssh >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber ssh secret/existing/ssh >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/existing/ssh >t/home/got 2>&1; exitok $? 0
@@ -885,17 +885,17 @@ $expected
 
 EOF
 
-	testing $version --noclobber rsa functionality without existing data
-	./safe --noclobber rsa secret/existing/rsa >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber rsa functionality without existing data
+	./safe --no-clobber rsa secret/existing/rsa >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	expected=$(./safe get secret/existing/rsa)
-	testing $version --noclobber rsa functionality with existing data
-	./safe --noclobber rsa secret/existing/rsa >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber rsa functionality with existing data
+	./safe --no-clobber rsa secret/existing/rsa >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to generate an RSA key at secret/existing/rsa as it is already present in Vault
 EOF
-	./safe --quiet --noclobber rsa secret/existing/rsa >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber rsa secret/existing/rsa >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/existing/rsa >t/home/got; exitok $? 0
@@ -904,17 +904,17 @@ $expected
 
 EOF
 
-	testing $version --noclobber dhparam functionality without existing data
-	./safe --noclobber dhparam secret/existing/dhparam >t/home/got; exitok $? 0 # don't care about stderr for this one
+	testing $version --no-clobber dhparam functionality without existing data
+	./safe --no-clobber dhparam secret/existing/dhparam >t/home/got; exitok $? 0 # don't care about stderr for this one
 	cat >t/home/want <<EOF ; diffok
 EOF
 	expected=$(./safe get secret/existing/dhparam)
-	testing $version --noclobber dhparam functionality with existing data
-	./safe --noclobber dhparam secret/existing/dhparam >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber dhparam functionality with existing data
+	./safe --no-clobber dhparam secret/existing/dhparam >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to generate a Diffie-Hellman key exchange parameters in secret/existing/dhparam as it is already present in Vault
 EOF
-	./safe --quiet --noclobber dhparam secret/existing/dhparam >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber dhparam secret/existing/dhparam >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/existing/dhparam >t/home/got; exitok $? 0
@@ -923,19 +923,19 @@ $expected
 
 EOF
 
-	testing $version --noclobber fmt functionality without existing data
+	testing $version --no-clobber fmt functionality without existing data
 	./safe set secret/existing/to-fmt val=value
-	./safe --noclobber fmt crypt-sha512 secret/existing/to-fmt val crypted >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber fmt crypt-sha512 secret/existing/to-fmt val crypted >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	expected=$(./safe get secret/existing/to-fmt:crypted)
-	testing $version --noclobber fmt functionality with existing data
+	testing $version --no-clobber fmt functionality with existing data
 	./safe set secret/existing/to-fmt val=value2
-	./safe --noclobber fmt crypt-sha512 secret/existing/to-fmt val crypted >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber fmt crypt-sha512 secret/existing/to-fmt val crypted >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to reformat secret/existing/to-fmt:val to crypted as it is already present in Vault
 EOF
-	./safe --quiet --noclobber fmt crypt-sha512 secret/existing/to-fmt val crypted >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber fmt crypt-sha512 secret/existing/to-fmt val crypted >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/existing/to-fmt:crypted >t/home/got; exitok $? 0
@@ -943,17 +943,17 @@ EOF
 $expected
 EOF
 
-	testing $version --noclobber x509 issue functionality without existing data
-	./safe --noclobber x509 issue --ca --name test secret/existing/cert >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber x509 issue functionality without existing data
+	./safe --no-clobber x509 issue --ca --name test secret/existing/cert >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	expected=$(./safe get secret/existing/cert)
-	testing $version --noclobber x509 issue functionality with existing data
-	./safe --noclobber x509 issue --ca --name test secret/existing/cert >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber x509 issue functionality with existing data
+	./safe --no-clobber x509 issue --ca --name test secret/existing/cert >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 Cowardly refusing to create a new certificate in secret/existing/cert as it is already present in Vault
 EOF
-	./safe --quiet --noclobber x509 issue --ca --name test secret/existing/cert >t/home/got 2>&1; exitok $? 0
+	./safe --quiet --no-clobber x509 issue --ca --name test secret/existing/cert >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 	./safe get secret/existing/cert >t/home/got; exitok $? 0
@@ -962,18 +962,18 @@ $expected
 
 EOF
 
-	./safe --noclobber x509 revoke --signed-by secret/existing/cert secret/existing/cert >t/home/got 2>&1; exitok $? 0
+	./safe --no-clobber x509 revoke --signed-by secret/existing/cert secret/existing/cert >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
-	testing $version --noclobber delete functionality
-	./safe --noclobber set secret/existing/to-delete key=val
-	./safe --noclobber delete -f secret/existing/to-delete >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber delete functionality
+	./safe --no-clobber set secret/existing/to-delete key=val
+	./safe --no-clobber delete -f secret/existing/to-delete >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
-	testing $version --noclobber recursive delete functionality
-	./safe --noclobber set secret/existing/to-delete key=val
-	./safe --noclobber set secret/existing/to-delete/subkey key=val
-	./safe --noclobber delete -Rf secret/existing/to-delete >t/home/got 2>&1; exitok $? 0
+	testing $version --no-clobber recursive delete functionality
+	./safe --no-clobber set secret/existing/to-delete key=val
+	./safe --no-clobber set secret/existing/to-delete/subkey key=val
+	./safe --no-clobber delete -Rf secret/existing/to-delete >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
 

--- a/tests
+++ b/tests
@@ -578,6 +578,336 @@ bar
 EOF
 	./safe get secret/move/from11:foo >t/home/got 2>t/home/errors; diffok
 
+  ###### --noclobber TESTS #####
+	testing $version --noclobber gen functionality without existing data
+	./safe --noclobber gen secret/existing/gen val >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	expected=$(./safe get secret/existing/gen)
+	testing $version --noclobber gen functionality with existing data
+	./safe --noclobber gen secret/existing/gen val >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to update secret/existing/gen:val as it is already present in Vault
+EOF
+	./safe get secret/existing/gen >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	testing $version --noclobber set functionality without existing data
+	./safe --noclobber set secret/existing/set val=test >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+val: test
+EOF
+	expected=$(./safe get secret/existing/set)
+	testing $version --noclobber set functionality with existing data
+	./safe --noclobber set secret/existing/set val=test2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+val: test2
+Cowardly refusing to update secret/existing/set, as the following keys would be clobbered: val
+EOF
+	./safe get secret/existing/set >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	testing $version --noclobber paste functionality without existing data
+	./safe --noclobber paste secret/existing/paste val=test >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+val: test
+EOF
+	expected=$(./safe get secret/existing/paste)
+	testing $version --noclobber paste functionality with existing data
+	./safe --noclobber paste secret/existing/paste val=test2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+val: test2
+Cowardly refusing to update secret/existing/paste, as the following keys would be clobbered: val
+EOF
+	./safe get secret/existing/paste >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	testing $version --noclobber ask functionality without existing data
+	./safe --noclobber ask secret/existing/ask val=test >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+val: test
+EOF
+	expected=$(./safe get secret/existing/ask)
+	testing $version --noclobber ask functionality with existing data
+	./safe --noclobber ask secret/existing/ask val=test2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+val: test2
+Cowardly refusing to update secret/existing/ask, as the following keys would be clobbered: val
+EOF
+	./safe get secret/existing/ask >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	testing $version --noclobber import functionality
+	./safe --noclobber import secret/existing/import <<EOF >t/home/got 2>&1; exitok $? 1
+{"secret/existing/import":{"should": "not import"}}
+EOF
+	cat >t/home/want <<EOF ; diffok
+!! --no-clobber is incompatible with safe import
+safe import - Import name/value pairs into the current Vault
+USAGE: safe import <backup/file.json
+EOF
+
+	testing $version --noclobber move functionality without existing data
+	./safe set secret/existing/to-move key=val
+	./safe --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	expected=$(./safe get secret/move-existing)
+	testing $version --noclobber move functionality with existing data
+	./safe set secret/existing/to-move key=val2
+	./safe --noclobber move secret/existing/to-move secret/move-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to copy/move data into secret/move-existing, as it would clobber existing data
+EOF
+	./safe get secret/move-existing >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	testing $version --noclobber move to key functionality without existing data
+	./safe set secret/existing/key-move key=val
+	./safe --noclobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	expected=$(./safe get secret/existing/key-move)
+	testing $version --noclobber move to key functionality with existing data
+	./safe set secret/existing/key-move key=val2
+	./safe --noclobber move secret/existing/key-move:key secret/existing/key-move:key2 >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to copy/move data into secret/existing/key-move:key2, as it would clobber existing data
+EOF
+	./safe get secret/existing/key-move >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	testing $version --noclobber recursive move functionality without existing data
+	./safe set secret/move-recursive/first key=val
+	./safe set secret/move-recursive/second key=val
+	./safe --noclobber move -Rf secret/move-recursive secret/move-recursive-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	testing $version --noclobber recursive move functionality with existing data
+	./safe set secret/move-recursive/first key=val2
+	./safe set secret/move-recursive/second key=val2
+	./safe set secret/move-recursive/third key=val2
+	./safe --noclobber move -Rf secret/move-recursive secret/move-recursive-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to copy/move data into secret/move-recursive-existing, as the following paths would be clobbered:
+- secret/move-recursive-existing/first
+- secret/move-recursive-existing/second
+EOF
+	./safe tree secret/move-recursive-existing >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+.
+└── secret/move-recursive-existing
+    ├── first
+    └── second
+
+EOF
+	./safe get secret/move-recursive-existing/first >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+--- # secret/move-recursive-existing/first
+key: val
+
+EOF
+	./safe get secret/move-recursive-existing/second >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+--- # secret/move-recursive-existing/second
+key: val
+
+EOF
+	./safe tree secret/move-recursive>t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+.
+└── secret/move-recursive
+    ├── first
+    ├── second
+    └── third
+
+EOF
+	./safe get secret/move-recursive/first >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+--- # secret/move-recursive/first
+key: val2
+
+EOF
+	./safe get secret/move-recursive/second >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+--- # secret/move-recursive/second
+key: val2
+
+EOF
+	./safe get secret/move-recursive/third >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+--- # secret/move-recursive/third
+key: val2
+
+EOF
+
+	testing $version --noclobber copy functionality without existing data
+	./safe set secret/existing/to-copy key=val
+	./safe --noclobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	expected=$(./safe get secret/copy-existing)
+	testing $version --noclobber copy functionality with existing data
+	./safe set secret/existing/to-copy key=val2
+	./safe --noclobber copy secret/existing/to-copy secret/copy-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to copy/move data into secret/copy-existing, as it would clobber existing data
+EOF
+	./safe get secret/copy-existing >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	testing $version --noclobber recurive copy functionality without existing data
+	./safe set secret/copy-recursive/first key=val
+	./safe set secret/copy-recursive/second key=val
+	./safe --noclobber copy -Rf secret/copy-recursive secret/copy-recursive-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	testing $version --noclobber recursive copy functionality with existing data
+	./safe set secret/copy-recursive/first key=val2
+	./safe set secret/copy-recursive/second key=val2
+	./safe set secret/copy-recursive/third key=val2
+	./safe --noclobber copy -Rf secret/copy-recursive secret/copy-recursive-existing >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to copy/move data into secret/copy-recursive-existing, as the following paths would be clobbered:
+- secret/copy-recursive-existing/first
+- secret/copy-recursive-existing/second
+EOF
+	./safe tree secret/copy-recursive-existing >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+.
+└── secret/copy-recursive-existing
+    ├── first
+    └── second
+
+EOF
+	./safe get secret/copy-recursive-existing/first >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+--- # secret/copy-recursive-existing/first
+key: val
+
+EOF
+	./safe get secret/copy-recursive-existing/second >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+--- # secret/copy-recursive-existing/second
+key: val
+
+EOF
+
+	testing $version --noclobber ssh functionality without existing data
+	./safe --noclobber ssh secret/existing/ssh >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	expected=$(./safe get secret/existing/ssh)
+	testing $version --noclobber ssh functionality with existing data
+	./safe --noclobber ssh secret/existing/ssh >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to generate an SSH key at secret/existing/ssh as it is already present in Vault
+EOF
+	./safe get secret/existing/ssh >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	testing $version --noclobber rsa functionality without existing data
+	./safe --noclobber rsa secret/existing/rsa >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	expected=$(./safe get secret/existing/rsa)
+	testing $version --noclobber rsa functionality with existing data
+	./safe --noclobber rsa secret/existing/rsa >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to generate an RSA key at secret/existing/rsa as it is already present in Vault
+EOF
+	./safe get secret/existing/rsa >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	testing $version --noclobber dhparam functionality without existing data
+	./safe --noclobber dhparam secret/existing/dhparam >t/home/got; exitok $? 0 # don't care about stderr for this one
+	cat >t/home/want <<EOF ; diffok
+EOF
+	expected=$(./safe get secret/existing/dhparam)
+	testing $version --noclobber dhparam functionality with existing data
+	./safe --noclobber dhparam secret/existing/dhparam >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to generate a DH Param in secret/existing/dhparam as it is already present in Vault
+EOF
+	./safe get secret/existing/dhparam >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	testing $version --noclobber fmt functionality without existing data
+	./safe set secret/existing/to-fmt val=value
+	./safe --noclobber fmt crypt-sha512 secret/existing/to-fmt val crypted >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	expected=$(./safe get secret/existing/to-fmt:crypted)
+	testing $version --noclobber fmt functionality with existing data
+	./safe set secret/existing/to-fmt val=value2
+	./safe --noclobber fmt crypt-sha512 secret/existing/to-fmt val crypted >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to reformat secret/existing/to-fmt:val to crypted as it is already present in Vault
+EOF
+	./safe get secret/existing/to-fmt:crypted >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+EOF
+
+	testing $version --noclobber x509 issue functionality without existing data
+	./safe --noclobber x509 issue --ca --name test secret/existing/cert >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	expected=$(./safe get secret/existing/cert)
+	testing $version --noclobber x509 issue functionality with existing data
+	./safe --noclobber x509 issue --ca --name test secret/existing/cert >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+Cowardly refusing to create a new certificate in secret/existing/cert as it is already present in Vault
+EOF
+	./safe get secret/existing/cert >t/home/got; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+$expected
+
+EOF
+
+	./safe --noclobber x509 revoke --signed-by secret/existing/cert secret/existing/cert >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	testing $version --noclobber delete functionality
+	./safe --noclobber set secret/existing/to-delete key=val
+	./safe --noclobber delete -f secret/existing/to-delete >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
+	testing $version --noclobber recursive delete functionality
+	./safe --noclobber set secret/existing/to-delete key=val
+	./safe --noclobber delete -Rf secret/existing/to-delete >t/home/got 2>&1; exitok $? 0
+	cat >t/home/want <<EOF ; diffok
+EOF
 
   ###### TREE TESTS ######
 

--- a/ui.go
+++ b/ui.go
@@ -21,19 +21,18 @@ func fail(err error) {
 	}
 }
 
-func keyPrompt(key string, confirm bool, secure bool) (string, string, error) {
+func parseKeyVal(key string) (string, string, error) {
 	if strings.Index(key, "=") >= 0 {
 		l := strings.SplitN(key, "=", 2)
 		if l[1] == "" {
-			l[1] = pr(l[0], confirm, secure)
+			return l[0], "", nil
 		}
 		ansi.Fprintf(os.Stderr, "%s: @G{%s}\n", l[0], l[1])
 		return l[0], l[1], nil
-
 	} else if strings.Index(key, "@") >= 0 {
 		l := strings.SplitN(key, "@", 2)
 		if l[1] == "" {
-			return l[0], pr(l[0], confirm, secure), nil
+			return l[0], "", nil
 		}
 		b, err := ioutil.ReadFile(l[1])
 		if err != nil {
@@ -42,7 +41,7 @@ func keyPrompt(key string, confirm bool, secure bool) (string, string, error) {
 		ansi.Fprintf(os.Stderr, "%s: <@C{%s}\n", l[0], l[1])
 		return l[0], string(b), nil
 	}
-	return key, pr(key, confirm, secure), nil
+	return key, "", nil
 }
 
 func pr(label string, confirm bool, secure bool) string {

--- a/vault/rsa.go
+++ b/vault/rsa.go
@@ -7,10 +7,10 @@ import (
 	"encoding/pem"
 )
 
-func rsakey(bits int) (string, string, string, error) {
+func rsakey(bits int) (string, string, error) {
 	key, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {
-		return "", "", "", err
+		return "", "", err
 	}
 
 	private := pem.EncodeToMemory(
@@ -22,7 +22,7 @@ func rsakey(bits int) (string, string, string, error) {
 
 	b, err := x509.MarshalPKIXPublicKey(key.Public())
 	if err != nil {
-		return "", "", "", err
+		return "", "", err
 	}
 	public := pem.EncodeToMemory(
 		&pem.Block{
@@ -31,5 +31,5 @@ func rsakey(bits int) (string, string, string, error) {
 		},
 	)
 
-	return string(private), string(public), "", nil
+	return string(private), string(public), nil
 }

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
+	"github.com/starkandwayne/goutils/ansi"
 	"github.com/tredoe/osutil/user/crypt/sha512_crypt"
 )
 
@@ -40,8 +41,12 @@ func (s *Secret) Get(key string) string {
 }
 
 // Set stores a value in the Secret, under the given key.
-func (s *Secret) Set(key, value string) {
+func (s *Secret) Set(key, value string, skipIfExists bool) error {
+	if s.Has(key) && skipIfExists {
+		return ansi.Errorf("@R{BUG: Something tried to overwrite the} @C{%s} @R{key, but it already existed, and --no-clobber was specified}", key)
+	}
 	s.data[key] = value
+	return nil
 }
 
 // Delete removes the entry with the given key from the Secret.
@@ -60,7 +65,7 @@ func (s *Secret) Empty() bool {
 	return len(s.data) == 0
 }
 
-func (s *Secret) Format(oldKey, newKey, fmtType string) error {
+func (s *Secret) Format(oldKey, newKey, fmtType string, skipIfExists bool) error {
 	if !s.Has(oldKey) {
 		return NewSecretNotFoundError(oldKey)
 	}
@@ -71,9 +76,15 @@ func (s *Secret) Format(oldKey, newKey, fmtType string) error {
 		if err != nil {
 			return err
 		}
-		s.data[newKey] = newVal
+		err = s.Set(newKey, newVal, skipIfExists)
+		if err != nil {
+			return err
+		}
 	case "base64":
-		s.data[newKey] = base64.StdEncoding.EncodeToString([]byte(oldVal))
+		err := s.Set(newKey, base64.StdEncoding.EncodeToString([]byte(oldVal)), skipIfExists)
+		if err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("%s is not a valid encoding for the `safe fmt` command", fmtType)
 	}
@@ -81,22 +92,28 @@ func (s *Secret) Format(oldKey, newKey, fmtType string) error {
 	return nil
 }
 
-func (s *Secret) DHParam(length int) error {
+func (s *Secret) DHParam(length int, skipIfExists bool) error {
 	dhparam, err := genDHParam(length)
 	if err != nil {
 		return err
 	}
-	s.Set("dhparam-pem", dhparam)
+	err = s.Set("dhparam-pem", dhparam, skipIfExists)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
 // Password creates and stores a new randomized password.
-func (s *Secret) Password(key string, length int, policy string) error {
+func (s *Secret) Password(key string, length int, policy string, skipIfExists bool) error {
 	r, err := random(length, policy)
 	if err != nil {
 		return err
 	}
-	s.data[key] = r
+	err = s.Set(key, r, skipIfExists)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -113,28 +130,42 @@ func crypt_sha512(pass string) (string, error) {
 	return sha, err
 }
 
-func (s *Secret) keypair(private, public string, fingerprint string, err error) error {
+func (s *Secret) keypair(private, public string, fingerprint string, skipIfExists bool) error {
+	err := s.Set("private", private, skipIfExists)
 	if err != nil {
 		return err
 	}
-	s.data["private"] = private
-	s.data["public"] = public
+	err = s.Set("public", public, skipIfExists)
+	if err != nil {
+		return err
+	}
 	if fingerprint != "" {
-		s.data["fingerprint"] = fingerprint
+		err = s.Set("fingerprint", fingerprint, skipIfExists)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 // RSAKey generates a new public/private keypair, and stores
 // it in the secret, under the 'public' and 'private' keys.
-func (s *Secret) RSAKey(bits int) error {
-	return s.keypair(rsakey(bits))
+func (s *Secret) RSAKey(bits int, skipIfExists bool) error {
+	private, public, fingerprint, err := rsakey(bits)
+	if err != nil {
+		return err
+	}
+	return s.keypair(private, public, fingerprint, skipIfExists)
 }
 
 // SSHKey generates a new public/private keypair, and stores
 // it in the secret, under the 'public' and 'private' keys.
-func (s *Secret) SSHKey(bits int) error {
-	return s.keypair(sshkey(bits))
+func (s *Secret) SSHKey(bits int, skipIfExists bool) error {
+	private, public, fingerprint, err := sshkey(bits)
+	if err != nil {
+		return err
+	}
+	return s.keypair(private, public, fingerprint, skipIfExists)
 }
 
 // JSON converts a Secret to its JSON representation and returns it as a string.

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -151,11 +151,11 @@ func (s *Secret) keypair(private, public string, fingerprint string, skipIfExist
 // RSAKey generates a new public/private keypair, and stores
 // it in the secret, under the 'public' and 'private' keys.
 func (s *Secret) RSAKey(bits int, skipIfExists bool) error {
-	private, public, fingerprint, err := rsakey(bits)
+	private, public, err := rsakey(bits)
 	if err != nil {
 		return err
 	}
-	return s.keypair(private, public, fingerprint, skipIfExists)
+	return s.keypair(private, public, "", skipIfExists)
 }
 
 // SSHKey generates a new public/private keypair, and stores

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -473,7 +473,7 @@ func (v *Vault) Copy(oldpath, newpath string, skipIfExists bool, quiet bool) err
 	if skipIfExists {
 		if _, err := v.Read(newpath); err == nil {
 			if !quiet {
-				ansi.Fprintf(os.Stderr, "@R{Cowardly refusing to copy/move data into} @C{%s}@R{, as it would clobber existing data}\n", newpath)
+				ansi.Fprintf(os.Stderr, "@R{Cowardly refusing to copy/move data into} @C{%s}@R{, as that would clobber existing data}\n", newpath)
 			}
 			return nil
 		} else if !IsNotFound(err) {

--- a/vault/x509.go
+++ b/vault/x509.go
@@ -301,7 +301,7 @@ func (x *X509) MakeCA(serial int64) {
 	x.CRL.TBSCertList.RevokedCertificates = make([]pkix.RevokedCertificate, 0)
 }
 
-func (x X509) Secret() (*Secret, error) {
+func (x X509) Secret(skipIfExists bool) (*Secret, error) {
 	s := NewSecret()
 
 	cert := string(pem.EncodeToMemory(&pem.Block{
@@ -313,21 +313,36 @@ func (x X509) Secret() (*Secret, error) {
 		Bytes: x509.MarshalPKCS1PrivateKey(x.PrivateKey),
 	}))
 
-	s.Set("certificate", cert)
-	s.Set("key", key)
-	s.Set("combined", cert+key)
+	err := s.Set("certificate", cert, skipIfExists)
+	if err != nil {
+		return s, err
+	}
+	err = s.Set("key", key, skipIfExists)
+	if err != nil {
+		return s, err
+	}
+	err = s.Set("combined", cert+key, skipIfExists)
+	if err != nil {
+		return s, err
+	}
 
 	if x.IsCA() {
-		s.Set("serial", x.Serial.Text(16))
+		err = s.Set("serial", x.Serial.Text(16), skipIfExists)
+		if err != nil {
+			return s, err
+		}
 
 		b, err := x.Certificate.CreateCRL(rand.Reader, x.PrivateKey, x.CRL.TBSCertList.RevokedCertificates, time.Now(), time.Now().Add(10*365*24*time.Hour))
 		if err != nil {
 			return s, err
 		}
-		s.Set("crl", string(pem.EncodeToMemory(&pem.Block{
+		err = s.Set("crl", string(pem.EncodeToMemory(&pem.Block{
 			Type:  "X509 CRL",
 			Bytes: b,
-		})))
+		})), skipIfExists)
+		if err != nil {
+			return s, err
+		}
 	}
 
 	return s, nil


### PR DESCRIPTION
    `safe --noclobber` will throw a message up to the user
    that they tried to overwrite an existing credential.
    This is supported in all known write-causing commands,
    except `safe import`.

    When existing credentials are encountered, safe will exit 0,
    as it successfully avoided clobbering the credential.

    If `--quiet` is specified, warning messages for clobbering-noops will be suppressed