### PR TITLE
Added --keys flag to get, paths and tree commands

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -21,11 +21,11 @@
 		},
 		{
 			"ImportPath": "github.com/starkandwayne/goutils/ansi",
-			"Rev": "1af0d9806cdff1eaa84c422f7bea313f3c4d073f"
+			"Rev": "d28cacc19462737f05e67bfee385190ffa593d65"
 		},
 		{
 			"ImportPath": "github.com/starkandwayne/goutils/tree",
-			"Rev": "1af0d9806cdff1eaa84c422f7bea313f3c4d073f"
+			"Rev": "d28cacc19462737f05e67bfee385190ffa593d65"
 		},
 		{
 			"ImportPath": "github.com/tredoe/osutil/user/crypt",

--- a/tests
+++ b/tests
@@ -130,6 +130,75 @@ whos: there
 EOF
 	yamlok
 
+	testing $version get operation with --yaml on single path
+	./safe get --yaml secret/handshake >t/home/got 2>t/home/errors
+	cat >t/home/want <<EOF
+---
+secret/handshake:
+  knock: knock
+  whos: there
+EOF
+	yamlok
+
+  testing $version get operation: multiple requests, some missing
+  ./safe set secret/other/thing get=this > /dev/null
+  ./safe get secret/handshake secret/other/thing secret/non-existant secret/handshake:passcode >t/home/got 2>&1 ; exitok $? 1
+  cat >t/home/want <<'EOF' ;
+!! Multiple errors found:
+   - no secret exists at path `secret/non-existant`
+   - no key `passcode` exists in secret `secret/handshake`
+EOF
+  diffok
+
+  testing $version get operation: multiple requests
+  ./safe get secret/handshake secret/other/thing >t/home/got 2>t/home/errors ; exitok $? 0
+  cat >t/home/want <<'EOF' ; yamlok
+---
+secret/handshake:
+  knock: knock
+  whos: there
+secret/other/thing:
+  get: this
+EOF
+
+  testing $version get --keys operation: multiple requests, some missing
+  ./safe get --keys secret/handshake secret/other/thing secret/code:pssst >t/home/got 2>t/home/warn ; exitok $? 0
+  cat >t/home/want <<'EOF' ;
+---
+secret/handshake:
+- knock
+- whos
+secret/other/thing:
+- get
+secret/code: []
+EOF
+  yamlok
+
+  mv t/home/warn t/home/got
+  cat >t/home/want <<'EOF'; diffok
+WARNING: no secret exists at path `secret/code`
+EOF
+
+
+  testing $version get --keys operation: single key
+  ./safe get --keys secret/handshake >t/home/got 2>&1 ; exitok $? 0
+  cat >t/home/want <<'EOF'
+knock
+whos
+EOF
+  diffok
+
+  testing $version get --keys operation: single key with --yaml
+  ./safe get --keys --yaml secret/handshake >t/home/got 2>&1 ; exitok $? 0
+  cat >t/home/want <<'EOF'
+---
+secret/handshake:
+- knock
+- whos
+EOF
+  yamlok
+  
+
 	testing $version basic check/exists operation
 	./safe exists secret/handshake        ; exitok $? 0
 	./safe exists secret/handshake:knock  ; exitok $? 0
@@ -310,7 +379,7 @@ EOF
 	cat >t/home/want <<EOF
 boop
 EOF
-	./safe get secret/delete/ten:beep >t/home/got t/home/errors; diffok
+	./safe get secret/delete/ten:beep >t/home/got 2>t/home/errors; diffok
 
 	testing $version recursively delete a secret that does not exist with -f should not fail
 	./safe delete -Rf secret/delete/gobbledegook; exitok $? 0
@@ -753,13 +822,10 @@ EOF
 	./safe --quiet --no-clobber move -Rf secret/move-recursive secret/move-recursive-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
-	./safe tree secret/move-recursive-existing >t/home/got; exitok $? 0
+	./safe paths secret/move-recursive-existing >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
-.
-└── secret/move-recursive-existing
-    ├── first
-    └── second
-
+secret/move-recursive-existing/first
+secret/move-recursive-existing/second
 EOF
 	./safe get secret/move-recursive-existing/first >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -773,14 +839,11 @@ EOF
 key: val
 
 EOF
-	./safe tree secret/move-recursive>t/home/got; exitok $? 0
+	./safe paths secret/move-recursive>t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
-.
-└── secret/move-recursive
-    ├── first
-    ├── second
-    └── third
-
+secret/move-recursive/first
+secret/move-recursive/second
+secret/move-recursive/third
 EOF
 	./safe get secret/move-recursive/first >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -845,13 +908,10 @@ EOF
 	./safe --quiet --no-clobber copy -Rf secret/copy-recursive secret/copy-recursive-existing >t/home/got 2>&1; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
 EOF
-	./safe tree secret/copy-recursive-existing >t/home/got; exitok $? 0
+	./safe paths secret/copy-recursive-existing >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
-.
-└── secret/copy-recursive-existing
-    ├── first
-    └── second
-
+secret/copy-recursive-existing/first
+secret/copy-recursive-existing/second
 EOF
 	./safe get secret/copy-recursive-existing/first >t/home/got; exitok $? 0
 	cat >t/home/want <<EOF ; diffok
@@ -1076,10 +1136,54 @@ secret/import/robot:
   mark: "2"
 secret/import/a/b/c:
   subkey: the value given
+secret/import/a/b/c/d:
+  subsubkey: really deep
 EOF
 	./safe import secret/import <t/home/want >/dev/null
 	./safe export secret/import >t/home/got 2>t/home/errors
 	yamlok
+
+  testing ${version} tree --keys
+  ./safe tree --keys secret/import/a/b/c >t/home/got 2>t/home/errors ; exitok $? 0
+  cat <<'EOF' >t/home/want ; diffok
+.
+└── secret/import/a/b/c
+    ├── :subkey
+    └── d
+        └── :subsubkey
+
+EOF
+  ./safe tree --keys secret/import/a secret/import/robot >t/home/got 2>t/home/errors ; exitok $? 0
+  cat <<'EOF' >t/home/want ; diffok
+.
+├── secret/import/a
+│   └── b/
+│       ├── c
+│       │   └── :subkey
+│       └── c/
+│           └── d
+│               └── :subsubkey
+└── secret/import/robot
+    ├── :mark
+    ├── :password
+    └── :username
+
+EOF
+
+  testing ${version} paths --keys
+  ./safe paths --keys secret/import/a/b/c >t/home/got 2>t/home/errors ; exitok $? 0
+  cat <<'EOF' >t/home/want ; diffok
+secret/import/a/b/c:subkey
+secret/import/a/b/c/d:subsubkey
+EOF
+  ./safe paths --keys secret/import/a secret/import/robot >t/home/got 2>t/home/errors ; exitok $? 0
+  cat <<'EOF' >t/home/want ; diffok
+secret/import/a/b/c:subkey
+secret/import/a/b/c/d:subsubkey
+secret/import/robot:mark
+secret/import/robot:password
+secret/import/robot:username
+EOF
 
 	testing ${version} x509 commands
 	./safe x509 issue                                                ; exitok $? 1 # need a path

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"sort"
 
 	"github.com/ghodss/yaml"
 	"github.com/starkandwayne/goutils/ansi"
@@ -38,6 +40,16 @@ func (s *Secret) Has(key string) bool {
 func (s *Secret) Get(key string) string {
 	x, _ := s.data[key]
 	return x
+}
+
+func (s *Secret) Keys() []string {
+	keys := reflect.ValueOf(s.data).MapKeys()
+	str_keys := make([]string, len(keys))
+	for i := 0; i < len(keys); i++ {
+		str_keys[i] = keys[i].String()
+	}
+	sort.Strings(str_keys)
+	return str_keys
 }
 
 // Set stores a value in the Secret, under the given key.

--- a/vendor/github.com/starkandwayne/goutils/ansi/printf.go
+++ b/vendor/github.com/starkandwayne/goutils/ansi/printf.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"unicode"
 
 	"github.com/mattn/go-isatty"
 )
@@ -38,7 +39,7 @@ var (
 		"W": "01;37", // white (BOLD)
 	}
 
-	re = regexp.MustCompile(`@[kKrRgGyYbBmMpPcCwW*]{.*?}`)
+	re = regexp.MustCompile(`(?s)@[kKrRgGyYbBmMpPcCwW*]{.*?}`)
 )
 
 var colorable = isatty.IsTerminal(os.Stdout.Fd())
@@ -54,9 +55,15 @@ func colorize(s string) string {
 		}
 		if m[1:2] == "*" {
 			rainbow := "RYGCBM"
+			skipCount := 0
 			s := ""
 			for i, c := range m[3 : len(m)-1] {
-				j := i % len(rainbow)
+				if unicode.IsSpace(c) { //No color wasted on whitespace
+					skipCount++
+					s += string(c)
+					continue
+				}
+				j := (i - skipCount) % len(rainbow)
 				s += "\033[" + colors[rainbow[j:j+1]] + "m" + string(c) + "\033[00m"
 			}
 			return s

--- a/vendor/github.com/starkandwayne/goutils/tree/cursor.go
+++ b/vendor/github.com/starkandwayne/goutils/tree/cursor.go
@@ -103,6 +103,21 @@ func (c *Cursor) Copy() *Cursor {
 	return other
 }
 
+// Contains ...
+func (c *Cursor) Contains(other *Cursor) bool {
+	if len(other.Nodes) < len(c.Nodes) {
+		return false
+	}
+	match := false
+	for i := range c.Nodes {
+		if c.Nodes[i] != other.Nodes[i] {
+			return false
+		}
+		match = true
+	}
+	return match
+}
+
 // Under ...
 func (c *Cursor) Under(other *Cursor) bool {
 	if len(c.Nodes) <= len(other.Nodes) {
@@ -249,7 +264,9 @@ func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
 				for i, v := range o.([]interface{}) {
 					sub, err := resolver(v, append(here, fmt.Sprintf("%d", i)), path, pos+1)
 					if err != nil {
-						return nil, err
+						if _, ok := err.(NotFoundError); !ok {
+							return nil, err
+						}
 					}
 					paths = append(paths, sub...)
 				}
@@ -258,7 +275,9 @@ func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
 				for k, v := range o.(map[string]interface{}) {
 					sub, err := resolver(v, append(here, k), path, pos+1)
 					if err != nil {
-						return nil, err
+						if _, ok := err.(NotFoundError); !ok {
+							return nil, err
+						}
 					}
 					paths = append(paths, sub...)
 				}
@@ -267,7 +286,9 @@ func (c *Cursor) Glob(tree interface{}) ([]*Cursor, error) {
 				for k, v := range o.(map[interface{}]interface{}) {
 					sub, err := resolver(v, append(here, fmt.Sprintf("%v", k)), path, pos+1)
 					if err != nil {
-						return nil, err
+						if _, ok := err.(NotFoundError); !ok {
+							return nil, err
+						}
 					}
 					paths = append(paths, sub...)
 				}

--- a/vendor/github.com/starkandwayne/goutils/tree/tree.go
+++ b/vendor/github.com/starkandwayne/goutils/tree/tree.go
@@ -67,3 +67,17 @@ func (n Node) flatten(prefix, sep string) []string {
 func (n Node) Paths(sep string) []string {
 	return n.flatten("", sep)
 }
+
+func (n Node) PathSegments() [][]string {
+	if len(n.Sub) == 0 {
+		return [][]string{[]string{n.Name}}
+	}
+	paths := make([][]string, 0)
+	for _, child := range n.Sub {
+		for _, segments := range child.PathSegments() {
+			segments := append([]string{n.Name}, segments...)
+			paths = append(paths, segments)
+		}
+	}
+	return paths
+}


### PR DESCRIPTION
The `--keys` flag modifies the commands to return key information for the
specified paths:

`get --keys [--yaml] PATH [...PATH]`:
  This will return a list of keys for the given path.  If multiple paths  are specified, the output will be YAML format with in the form of:

    ---
    /first/path/requested:
    - key1
    - key2
    /second/path/requested:
    - keyA

  You can force the output to YAML when requesting for a single path by using the `--yaml` flag.

`tree --keys [PATH [...PATH]]`:
  This will include the keys found in edge nodes of the tree.  This cannot be used with the -d option.

`paths --keys [PATH [...PATH]]`:
  This will output the full paths to all keys under the specified path(s).

---

Along with the above, there was some cleanup to make more consistent
output of the tree, paths, and get command, especially around when
multiple PATHS are specified.