### PR TITLE
Allow empty secrets to be set

### DIFF
--- a/main.go
+++ b/main.go
@@ -553,7 +553,7 @@ func main() {
 		exists := (err == nil)
 		clobberKeys := []string{}
 		for _, arg := range args {
-			k, v, err := parseKeyVal(arg)
+			k, v, missing, err := parseKeyVal(arg)
 			if err != nil {
 				return err
 			}
@@ -565,7 +565,7 @@ func main() {
 			if len(clobberKeys) > 0 {
 				continue
 			}
-			if v == "" {
+			if missing {
 				v = pr(k, prompt, insecure)
 			}
 			if err != nil {

--- a/tests
+++ b/tests
@@ -336,6 +336,59 @@ EOF
 		echo "ok"
 	fi
 
+	testing $version set key from file
+	echo -n "this is a value" >t/home/value-file
+	echo -n "" >t/home/empty-file
+	cat >t/home/long-file <<EOF
+this
+is
+a
+multiline
+value
+EOF
+	./safe set secret/from-files/content value@t/home/value-file blank@t/home/empty-file long@t/home/long-file ; exitok $? 0
+	./safe get secret/from-files/content --yaml >t/home/got 2>t/home/errors ; exitok $? 0
+	cat >t/home/want <<EOF ; cp t/home/want /tmp; yamlok
+---
+secret/from-files/content:
+  value: this is a value
+  blank: ""
+  long: |
+    this
+    is
+    a
+    multiline
+    value
+EOF
+
+	testing $version set key to empty value
+	./safe set secret/setec/astronomy too= many="" ; exitok $? 0
+	./safe get secret/setec/astronomy --yaml >t/home/got 2>t/home/errors ; exitok $? 0
+	cat >t/home/want <<EOF ; cp t/home/want /tmp; yamlok
+---
+secret/setec/astronomy:
+  too: ""
+  many: ""
+EOF
+
+	testing $version set key from file - error conditions
+	./safe set secret/from-file/content nothing@non-existant-file 2>t/home/got >t/home/null; exitok $? 1
+	cat > t/home/want<<EOF ; diffok
+!! Failed to read contents of non-existant-file: open non-existant-file: no such file or directory
+EOF
+	mv -f t/home/null t/home/got
+	echo -n "" > t/home/want ; diffok
+	./safe get secret/from-file/content:nothing; exitok $? 1
+
+	./safe set secret/from-file/content no-file@ 2>t/home/got >t/home/null; exitok $? 1
+	cat > t/home/want<<EOF ; diffok
+!! No file specified: expecting no-file@<filename>
+EOF
+	mv -f t/home/null t/home/got
+	echo -n "" > t/home/want ; diffok
+	./safe get secret/from-file/content:no-file; exitok $? 1
+	
+
 	###### DELETE TESTS ######
 
 	testing $version secret deletion

--- a/ui.go
+++ b/ui.go
@@ -21,27 +21,28 @@ func fail(err error) {
 	}
 }
 
-func parseKeyVal(key string) (string, string, error) {
+func parseKeyVal(key string) (string, string, bool, error) {
 	if strings.Index(key, "=") >= 0 {
 		l := strings.SplitN(key, "=", 2)
 		if l[1] == "" {
-			return l[0], "", nil
+			return l[0], "", false, nil
 		}
 		ansi.Fprintf(os.Stderr, "%s: @G{%s}\n", l[0], l[1])
-		return l[0], l[1], nil
+		return l[0], l[1], false, nil
 	} else if strings.Index(key, "@") >= 0 {
 		l := strings.SplitN(key, "@", 2)
 		if l[1] == "" {
-			return l[0], "", nil
+			return l[0], "", true, fmt.Errorf("No file specified: expecting %s@<filename>", l[0])
 		}
+		// TODO: Add support for - to read from STDIN
 		b, err := ioutil.ReadFile(l[1])
 		if err != nil {
-			return l[0], "", fmt.Errorf("Failed to read contents of %s: %s", l[1], err)
+			return l[0], "", true, fmt.Errorf("Failed to read contents of %s: %s", l[1], err)
 		}
 		ansi.Fprintf(os.Stderr, "%s: <@C{%s}\n", l[0], l[1])
-		return l[0], string(b), nil
+		return l[0], string(b), false, nil
 	}
-	return key, "", nil
+	return key, "", true, nil
 }
 
 func pr(label string, confirm bool, secure bool) string {


### PR DESCRIPTION
This resolves the regression that prevented empty strings or references
to empty files to be used to set secrets