### PR TITLE
New `safe fmt` (crypt) formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ in an alternate format (for htpass files, or /etc/shadow).
 Currently supported formats:
 
 - base64
+- bcrypt
+- crypt-md5
+- crypt-sha256
 - crypt-sha512
 
 ```

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,10 @@
+## New Features
+
+- `safe fmt` picked up some new formats: `bcrypt` for
+  Blowfish-based bcrypt (best for password storage), `crypt-md5`
+  for legacy systems that need MD5 hashes, and `crypt-sha256` for
+  a middle-ground between MD5 and SHA-512.
+
 ## Improvements
 
 - The pki-backend commands in safe have now been officially

--- a/main.go
+++ b/main.go
@@ -1277,6 +1277,9 @@ using the 'crypt-sha512' format.
 Supported formats:
 
     base64          Base64 encodes the value
+    bcrypt          Salt and hash the value, using bcrypt (Blowfish, in crypt format).
+    crypt-md5       Salt and hash the value, using MD5, in crypt format (legacy).
+    crypt-sha256    Salt and hash the value, using SHA-256, in crypt format.
     crypt-sha512    Salt and hash the value, using SHA-512, in crypt format.
 
 `,

--- a/tests
+++ b/tests
@@ -397,7 +397,41 @@ EOF
 	mv -f t/home/null t/home/got
 	echo -n "" > t/home/want ; diffok
 	./safe get secret/from-file/content:no-file; exitok $? 1
-	
+
+
+
+	###### FORMAT TESTS ######
+	testing $version fmt - all formats
+	./safe gen secret/fmt/formats original
+	./safe get secret/fmt/formats:original; exitok $? 0
+
+	./safe fmt base64       secret/fmt/formats original base64;       exitok $? 0
+	./safe fmt bcrypt       secret/fmt/formats original bcrypt;       exitok $? 0
+	./safe fmt crypt-md5    secret/fmt/formats original crypt-md5;    exitok $? 0
+	./safe fmt crypt-sha256 secret/fmt/formats original crypt-sha256; exitok $? 0
+	./safe fmt crypt-sha512 secret/fmt/formats original crypt-sha512; exitok $? 0
+
+	./safe get secret/fmt/formats:base64;       exitok $? 0
+	./safe get secret/fmt/formats:bcrypt;       exitok $? 0
+	./safe get secret/fmt/formats:crypt-md5;    exitok $? 0
+	./safe get secret/fmt/formats:crypt-sha256; exitok $? 0
+	./safe get secret/fmt/formats:crypt-sha512; exitok $? 0
+
+	# note that the tests do not support the optional parameters in crypt format
+	# (i.e. `$<id>[$<param>=<value>(,<param>=<value>)*][$<salt>[$<hash>]]`)
+	testing $version fmt - bcrypt
+	./safe get secret/fmt/formats:bcrypt | grep -qE '^\$2[axy]?\$[a-zA-Z0-9+/=]+\$.+'; exitok $? 0
+
+	testing $version fmt - crypt-md5
+	./safe get secret/fmt/formats:crypt-md5 | grep -qE '^\$1\$[a-zA-Z0-9+/=]+\$.+'; exitok $? 0
+
+	testing $version fmt - crypt-sha256
+	./safe get secret/fmt/formats:crypt-sha256 | grep -qE '^\$5\$[a-zA-Z0-9+/=]+\$.+'; exitok $? 0
+
+	testing $version fmt - crypt-sha512
+	./safe get secret/fmt/formats:crypt-sha512 | grep -qE '^\$6\$[a-zA-Z0-9+/=]+\$.+'; exitok $? 0
+
+
 
 	###### DELETE TESTS ######
 


### PR DESCRIPTION
Introduce new formatting options for a wider applicability in
hashed-password scenarios:

  - `bcrypt` - Blowfish-based bcrypt for secure password hashing
  - `crypt-md5` - MD5 support for legacy systems
  - `crypt-sha256` - SHA-256 support to complement our SHA-512 support.

Fixes #96