### PR TITLE
Support finding CAs on OS X/darwin

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,5 @@
+# Bug Fixes
+
+- Resolves an issue where `safe` on Darwin would fail to pull the root CAs
+  properly, and was unable to find custom CAs. This does not appear to affect
+  the Linux version.


### PR DESCRIPTION
Previously, safe was unable to find any custom CAs added to the system keychains as trusted authorities. This should keep the same behavior on linux, and allow darwin binaries to work properly.