### PR TITLE
New `safe init` command

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -4,6 +4,9 @@
   Vault with custom keying configuration, greatly simplifying
   standup operations.
 
+- `safe rekey` now features the same flags as `safe init` for
+  consistency and uniformity.
+
 # Improvements
 
 - Remove silly debugging statement that escaped into the wild.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,9 @@
+# New Features
+
+- `safe init` is a new command that lets you initialize a new
+  Vault with custom keying configuration, greatly simplifying
+  standup operations.
+
 # Improvements
 
 - Remove silly debugging statement that escaped into the wild.

--- a/tests
+++ b/tests
@@ -295,6 +295,7 @@ for version in ${versions[@]}; do
   restart_vault_server
   clearvault
 
+
    ######   ######## ########       ##  ######  ######## ########
   ##    ##  ##          ##         ##  ##    ## ##          ##
   ##        ##          ##        ##   ##       ##          ##
@@ -2022,15 +2023,23 @@ EOF
     (run; ./safe x509 check secret/x509/imposter --ca)                     ; exitok $? 1
   fi
 
-  # REKEY TESTS
+
+  ########  ######## ##    ## ######## ##    ##
+  ##     ## ##       ##   ##  ##        ##  ##
+  ##     ## ##       ##  ##   ##         ####
+  ########  ######   #####    ######      ##
+  ##   ##   ##       ##  ##   ##          ##
+  ##    ##  ##       ##   ##  ##          ##
+  ##     ## ######## ##    ## ########    ##
+
   testing ${version} safe rekey
-  now trying to rekey with a lower num-unseal-keys than keys-to-unseal should error
-  (run; ./safe rekey --num-unseal-keys 3 --keys-to-unseal 5 >t/home/got 2>&1); exitok $? 1
+  now trying to rekey to require 5/3 keys should error
+  (run; ./safe rekey --keys 3 --threshold 5 >t/home/got 2>&1); exitok $? 1
   cat <<'EOF' > t/home/want ; diffok
 !! You specified only 3 unseal keys, but are requiring 5 keys to unseal vault. This is bad.
 EOF
-  now trying to rekey with only one key-to-unseal but multiple num-unseal-keys should error
-  (run; ./safe rekey --keys-to-unseal 1 --num-unseal-keys 2 >t/home/got 2>&1); exitok $? 1
+  now trying to rekey to require 1/1+n keys should error
+  (run; ./safe rekey --threshold 1 --keys 2 >t/home/got 2>&1); exitok $? 1
   cat <<'EOF' > t/home/want ; diffok
 !! When specifying more than 1 unseal key, you must also have more than one key required to unseal.
 EOF
@@ -2061,10 +2070,12 @@ EOF
   (./safe curl GET sys/rekey/init | grep '"started":false'); exitok $? 0
 
 
-  now trying to rekey with no gpg usage
+  now restarting vault server to start over
   restart_vault_server
+  now validating that the restarted vault is unsealed
   (./safe set secret/handshake knock=knock); exitok $? 0
-  (run; echo "$unseal_key" | ./safe rekey --num-unseal-keys 1 > t/home/original); exitok $? 0
+  now trying to rekey without using gpg
+  (run; echo "$unseal_key" | ./safe rekey --keys 1 > t/home/original); exitok $? 0
   cat t/home/original | sed -E 's/Unseal key 1: .*/Unseal key 1: REPLACED/' > t/home/got
   cat <<'EOF' >t/home/want ; diffok
 Your Vault has been re-keyed. Please take note of your new unseal keys and store them safely!
@@ -2084,11 +2095,11 @@ EOF
 
   if [[ -z "${SAFE_DISABLE_GPG_TESTS:-}" ]]; then
     testing ${version} safe rekey --gpg
-    now trying to rekey with the num-unseal-keys otherthan the number of gpg keys should error
+    now trying to rekey with the threshold other than the number of gpg keys should error
     gpg --import assets/gpg.pubkey
-    (run; ./safe rekey --num-unseal-keys 3 --gpg safe-testing@safe.com >t/home/got 2>&1); exitok $? 1
+    (run; ./safe rekey --keys 3 --gpg safe-testing@safe.com >t/home/got 2>&1); exitok $? 1
     cat <<'EOF' > t/home/want ; diffok
-!! Both --gpg and --num-unseal-keys were specified, and their counts did not match.
+!! Both --gpg and --keys were specified, and their counts did not match.
 EOF
 
     now trying to rekey with a gpg key that is not in the keyring fails
@@ -2097,7 +2108,7 @@ EOF
 !! No GPG key found for not-there@missing.com in the local keyring
 EOF
 
-    now trying to rekey with gpg keys matching the num-unseal-keys
+    now trying to rekey with gpg keys matching the threshold
     restart_vault_server
     (./safe set secret/handshake knock=knock); exitok $? 0
     gpg --import assets/gpg.pubkey

--- a/vault/init.go
+++ b/vault/init.go
@@ -1,0 +1,63 @@
+package vault
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+func (v *Vault) Init(nkeys, threshold int) ([]string, string, error) {
+	if threshold > nkeys {
+		return nil, "", fmt.Errorf("cannot require %d/%d keys -- threshold is too high!")
+	}
+
+	in := struct {
+		Keys      int `json:"secret_shares"`
+		Threshold int `json:"secret_threshold"`
+	}{
+		Keys:      nkeys,
+		Threshold: threshold,
+	}
+	b, err := json.Marshal(&in)
+	if err != nil {
+		return nil, "", err
+	}
+
+	req, err := http.NewRequest("POST", v.url("/v1/sys/init"), bytes.NewReader(b))
+	if err != nil {
+		return nil, "", err
+	}
+
+	res, err := v.request(req)
+	if err != nil {
+		return nil, "", err
+	}
+
+	b, err = ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var out struct {
+		Keys  []string `json:"keys_base64"`
+		Token string   `json:"root_token"`
+
+		Errors []string `json:"errors"`
+	}
+	err = json.Unmarshal(b, &out)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if res.StatusCode != 200 {
+		if len(out.Errors) > 0 {
+			return nil, "", fmt.Errorf("%s", out.Errors[0])
+		} else {
+			return nil, "", fmt.Errorf("an unspecified error has occurred.")
+		}
+	}
+
+	return out.Keys, out.Token, nil
+}


### PR DESCRIPTION
Initializes a brand new Vault.  Common interactions:

```
# initialize a vault with a single unseal key
safe init --single

# initialize a vault with default 3/5 keys
safe init

# initialize with 2/18
safe init --keys 18 --threshold 2

# initialize the vault but don't immediately unseal it
safe init --sealed

# initialize, but print the keys / token in machine-friendly JSON
safe init --json
```

The `--json` mode allows management via json-savvy automatons:

```
→  ./safe init --json --single | jq -r .
{
  "seal_keys": [
    "f4aQT0vxtbzf8EvrR2Dhry4qAKHwC1mfTPv26Z6Zud8="
  ],
  "root_token": "2aa693cc-8ed3-985b-ef50-c32821ab6f94"
}
```

If the Vault is already sealed, you get a nice error message like:

```
→  ./safe init
!! Vault is already initialized
```

I re-named the flags for `safe rekey` to match those of `safe init`, but kept the old names around to avoid breaking scripts in the wild.

Fixes #117 