### PR TITLE
Windows Compatibility

### DIFF
--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -38,7 +38,7 @@ fi
 
 go version; echo; echo
 #?#ORIGIN=$(pwd)
-TARGETS=${TARGETS:-linux/amd64 darwin/amd64}
+TARGETS=${TARGETS:-linux/amd64 darwin/amd64 windows/amd64}
 ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )
 
 pushd $REPO_ROOT

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"sort"
@@ -554,6 +555,8 @@ listener "tcp" {
 					storageKey = "backend"
 				}
 			}
+		} else {
+			return fmt.Errorf("@R{Vault is not currently installed or located in $PATH}")
 		}
 	doneVersionCheck:
 
@@ -561,6 +564,7 @@ listener "tcp" {
 		if opt.Local.Memory {
 			fmt.Fprintf(f, "%s \"inmem\" {}\n", storageKey)
 		} else {
+			opt.Local.File = filepath.ToSlash(opt.Local.File)
 			fmt.Fprintf(f, "%s \"file\" { path = \"%s\" }\n", storageKey, opt.Local.File)
 			if _, err := os.Stat(opt.Local.File); err == nil || !os.IsNotExist(err) {
 				keys = append(keys, pr("Unseal Key", false, true))

--- a/rc/config.go
+++ b/rc/config.go
@@ -3,6 +3,7 @@ package rc
 import (
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 
 	fmt "github.com/jhunt/go-ansi"
@@ -28,12 +29,23 @@ type oldConfig struct {
 	SkipVerify map[string]bool        `yaml:"SkipVerify"`
 }
 
+func userHomeDir() string {
+	if runtime.GOOS == "windows" {
+		home := os.Getenv("USERPROFILE")
+		if home == "" {
+			home = os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		}
+		return home
+	}
+	return os.Getenv("HOME")
+}
+
 func saferc() string {
-	return fmt.Sprintf("%s/.saferc", os.Getenv("HOME"))
+	return fmt.Sprintf("%s/.saferc", userHomeDir())
 }
 
 func svtoken() string {
-	return fmt.Sprintf("%s/.svtoken", os.Getenv("HOME"))
+	return fmt.Sprintf("%s/.svtoken", userHomeDir())
 }
 
 func (legacy *oldConfig) convert() Config {

--- a/vault/utils.go
+++ b/vault/utils.go
@@ -1,7 +1,9 @@
 package vault
 
 import (
+	"os"
 	"regexp"
+	"runtime"
 	"strings"
 )
 
@@ -32,4 +34,15 @@ func Canonicalize(p string) string {
 	p = re.ReplaceAllString(p, "/")
 
 	return p
+}
+
+func userHomeDir() string {
+	if runtime.GOOS == "windows" {
+		home := os.Getenv("USERPROFILE")
+		if home == "" {
+			home = os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		}
+		return home
+	}
+	return os.Getenv("HOME")
 }

--- a/vendor/github.com/jhunt/go-ansi/README.md
+++ b/vendor/github.com/jhunt/go-ansi/README.md
@@ -58,6 +58,26 @@ The colorizing formatting codes all look like this:
 You can now also activate super-awesome RAINBOW mode with
 `@*{...}`
 
+To Colorize or Not To Colorize?
+-------------------------------
+
+Is that the question?
+
+This library tries its hardest to determine whether or not
+colorized sequences should be honored or removed outright, based
+on the terminal-iness of the output medium.  For example, if
+stdout is being redirected to a file, `ansi.Printf` will strip out
+the color sequences altogether.
+
+Sometimes this is impossible.  Specifically, for things like
+`ansi.Errorf` and `ansi.Sprintf`, the library has no idea whether
+or not the ultimate output stream even supports color code
+sequences.  In those cases, you can check yourself, with
+`ansi.CanColorize(io.Writer)` -- it returns true if the io.Writer
+you passed it is hooked up to a terminal.  `ansi.ShouldColorize()`
+is similar, except that it also returns true if
+`ansi.ForceColor(true)` has been called.
+
 Contributing
 ------------
 

--- a/vendor/github.com/jhunt/go-ansi/printf.go
+++ b/vendor/github.com/jhunt/go-ansi/printf.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"runtime"
 	"unicode"
 
 	"github.com/mattn/go-isatty"
@@ -77,20 +78,32 @@ func colorize(s string) string {
 	})
 }
 
+func CanColorize(out io.Writer) bool {
+	f, ok := out.(*os.File)
+	if runtime.GOOS == "windows" {
+		ok = false
+	}
+	return ok && isatty.IsTerminal(f.Fd())
+}
+
+func ShouldColorize(out io.Writer) bool {
+	return force || CanColorize(out)
+}
+
 func Printf(format string, a ...interface{}) (int, error) {
-	s := fmt.Sprintf(colorize(format), a...)
-	if !force && !isatty.IsTerminal(os.Stdout.Fd()) {
+	s := colorize(format)
+	if !ShouldColorize(os.Stdout) {
 		s = strip(s)
 	}
-	return fmt.Printf("%s", s)
+	return fmt.Printf(s, a...)
 }
 
 func Fprintf(out io.Writer, format string, a ...interface{}) (int, error) {
-	s := fmt.Sprintf(colorize(format), a...)
-	if f, ok := out.(*os.File); ok && !force && !isatty.IsTerminal(f.Fd()) {
+	s := colorize(format)
+	if !ShouldColorize(out) {
 		s = strip(s)
 	}
-	return fmt.Fprintf(out, "%s", s)
+	return fmt.Fprintf(out, s, a...)
 }
 
 func Sprintf(format string, a ...interface{}) string {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -8,10 +8,10 @@
 			"revision": "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
 		},
 		{
-			"checksumSHA1": "DE6jvAzC7h6Mczf8Tr0X5SkzeNI=",
+			"checksumSHA1": "1yd1889u0iCn8v0rub4ym2LbUeE=",
 			"path": "github.com/jhunt/go-ansi",
-			"revision": "52b391f2c38fac4d0693caffcf1c01f4cabced89",
-			"revisionTime": "2017-11-20T21:45:13Z"
+			"revision": "403d5f0d9ccb2ececa88041269b5063cdf60163f",
+			"revisionTime": "2018-06-30T01:38:15Z"
 		},
 		{
 			"checksumSHA1": "cMK2e7uclcXbkpLtyuV+6yRh0Bw=",


### PR DESCRIPTION
Updated home directory path recognition to be compatible with windows and linux.
Updated the CACertPool to correctly use windows cert roots
Updated vault local to throw an error if vault is not installed (instead of panicking)
Updated file paths to be compatible with both slashes '\' or '/'
Updated ci to build and release a version compiled for 64bit windows