### PR TITLE
Fix ls mount listing

### DIFF
--- a/main.go
+++ b/main.go
@@ -1375,12 +1375,13 @@ paths/keys.
 		Usage:   "safe ls [-1] [PATH ...]",
 		Type:    NonDestructiveCommand,
 		Description: `
+  Specifying the -1 flag will print one result per line.
 `,
 	}, func(command string, args ...string) error {
 		rc.Apply(opt.UseTarget)
 		v := connect(true)
 		if len(args) == 0 {
-			secrets, err := v.Mounts("secret")
+			secrets, err := v.Mounts("generic")
 			if err != nil {
 				return err
 			}
@@ -1392,15 +1393,12 @@ paths/keys.
 			secrets = append(secrets, kvs...)
 			sort.Strings(secrets)
 
+			separator := "  \n"
 			if opt.List.Single {
-				for _, path := range secrets {
-					fmt.Printf("@B{%s/}\n", path)
-				}
-			} else {
-				for _, path := range secrets {
-					fmt.Printf("@B{%s/}  ", path)
-				}
-				fmt.Printf("\n")
+				separator = "\n"
+			}
+			for _, path := range secrets {
+				fmt.Printf("@B{%s/}%s", strings.TrimRight(path, "/"), separator)
 			}
 			return nil
 		}

--- a/main.go
+++ b/main.go
@@ -1393,12 +1393,15 @@ paths/keys.
 			secrets = append(secrets, kvs...)
 			sort.Strings(secrets)
 
-			separator := "  \n"
+			separator := "  "
 			if opt.List.Single {
 				separator = "\n"
 			}
 			for _, path := range secrets {
 				fmt.Printf("@B{%s/}%s", strings.TrimRight(path, "/"), separator)
+			}
+			if !opt.List.Single {
+				fmt.Printf("\n")
 			}
 			return nil
 		}


### PR DESCRIPTION
First thing is that the mount listing was looking for mounts of type
secret, which is not, nor to my knowledge has ever been, a thing. So
I changed that to "generic". Also, there was a formatting error where
on newer versions of Vault, mounts would be listed with a trailing
double slash which, while innocuous, is effectively more annoying
than the other bug where mounts weren't all listing in the first place.