### PR TITLE
Handle Missing CRLs and Serial Numbers in CAs

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,8 @@
+# Improvements
+
+- `safe x509 renew` can now recover from missing CRLs and missing
+  serial numbers, in case you've imported the certificate and
+  private key from somewhere else.
+
+- `safe x509 validate` now complains is a certificate is listed as
+  a CA but does not have its serial number or CRL.

--- a/main.go
+++ b/main.go
@@ -2314,6 +2314,15 @@ The following options are recognized:
 				return err
 			}
 
+			if cert.IsCA() {
+				if cert.Serial == nil {
+					return fmt.Errorf("%s is missing its serial number tracker", path)
+				}
+				if cert.CRL == nil {
+					return fmt.Errorf("%s is missing its certificate revocation list", path)
+				}
+			}
+
 			fmt.Printf("@G{%s} checks out.\n", path)
 		}
 

--- a/tests
+++ b/tests
@@ -1775,8 +1775,37 @@ EOF
     now checking that renew does not change certificate attributes, other than ttl
     eq_or_diff "$(./safe x509 show secret/renew/orig | grep -Ev 'secret/re|valid from|expires in')" \
                "$(./safe x509 show secret/renew/cert | grep -Ev 'secret/re|valid from|expires in')"
-  fi
 
+
+    now removing the CRL from a CA certificate
+    (run; ./safe rm secret/renew/ca:crl); exitok $? 0
+    no_key secret/renew/ca:crl
+
+    now checking that a CA without a CRL is invalid
+    (run; ./safe x509 validate secret/renew/ca); exitok $? 1
+
+    now checking that renew can re-constitute a missing CRL
+    (run; ./safe x509 renew secret/renew/ca); exitok $? 0
+    ok_key secret/renew/ca:crl
+
+    now checking that a CA is valid again
+    (run; ./safe x509 validate secret/renew/ca); exitok $? 0
+
+
+    now removing the serial from a CA certificate
+    (run; ./safe rm secret/renew/ca:serial); exitok $? 0
+    no_key secret/renew/ca:serial
+
+    now checking that a CA without a serial is invalid
+    (run; ./safe x509 validate secret/renew/ca); exitok $? 1
+
+    now checking that renew can re-constitute a missing CA serial
+    (run; ./safe x509 renew secret/renew/ca); exitok $? 0
+    ok_key secret/renew/ca:serial
+
+    now checking that a CA is valid again
+    (run; ./safe x509 validate secret/renew/ca); exitok $? 0
+  fi
 
   #######
   clearvault

--- a/vault/x509.go
+++ b/vault/x509.go
@@ -476,11 +476,21 @@ func (x X509) Secret(skipIfExists bool) (*Secret, error) {
 	}
 
 	if x.IsCA() {
+		if x.Serial == nil {
+			x.Serial = big.NewInt(1)
+		}
+
 		err = s.Set("serial", x.Serial.Text(16), skipIfExists)
 		if err != nil {
 			return s, err
 		}
 
+		if x.CRL == nil {
+			x.CRL = &pkix.CertificateList{}
+		}
+		if x.CRL.TBSCertList.RevokedCertificates == nil {
+			x.CRL.TBSCertList.RevokedCertificates = make([]pkix.RevokedCertificate, 0)
+		}
 		b, err := x.Certificate.CreateCRL(rand.Reader, x.PrivateKey, x.CRL.TBSCertList.RevokedCertificates, time.Now(), time.Now().Add(10*365*24*time.Hour))
 		if err != nil {
 			return s, err


### PR DESCRIPTION
`safe x509 renew` can now recover from missing CRLs and missing
serial numbers, in case you've imported the certificate and
private key from somewhere else.

`safe x509 validate` now complains is a certificate is listed as
a CA but does not have its serial number or CRL.