### PR TITLE
Vault API code converted to use vaultkv

### DIFF
--- a/main.go
+++ b/main.go
@@ -757,7 +757,7 @@ Vault will remain sealed).
 		if !opt.Init.Sealed {
 			if st, err := v.Strongbox(); err == nil {
 				for addr := range st {
-					v.URL = addr
+					v.SetURL(addr)
 					if err := v.Unseal(keys); err != nil {
 						fmt.Fprintf(os.Stderr, "!!! unable to unseal newly-initialized vault (at %s): %s\n", addr, err)
 					}
@@ -861,7 +861,7 @@ Vault will remain sealed).
 		for addr, state := range st {
 			if state == "sealed" {
 				n++
-				v.URL = addr
+				v.SetURL(addr)
 				nkeys, err = v.SealKeys()
 				if err != nil {
 					return err
@@ -882,7 +882,7 @@ Vault will remain sealed).
 			for addr, state := range st {
 				if state == "sealed" {
 					fmt.Printf("unsealing @G{%s}...\n", addr)
-					v.URL = addr
+					v.SetURL(addr)
 					if err = v.Unseal(keys); err != nil {
 						return err
 					}
@@ -919,7 +919,7 @@ Vault will remain sealed).
 		for n > 0 {
 			for addr, state := range st {
 				if state == "unsealed" {
-					v.URL = addr
+					v.SetURL(addr)
 
 					sealed, err := v.Seal()
 					if err != nil {

--- a/tests
+++ b/tests
@@ -2249,18 +2249,6 @@ EOF
   cat <<'EOF' > t/home/want ; diffok
 !! When specifying more than 1 unseal key, you must also have more than one key required to unseal.
 EOF
-  # force a rekey, causing problems with the initialization
-  now forcing a manual rekey to cause the next failure should succeed
-  (./safe curl POST sys/rekey/init '{"secret_threshold":1,"secret_shares":1}'); exitok $? 0
-  now failures from Vault during the rekey initialization should error
-  (run; ./safe rekey > t/home/got 2>&1); exitok $? 1
-  cat <<'EOF' > t/home/want ; diffok
-!! Failed to start rekeying vault:
-["rekey already in progress"]
-EOF
-  now forcing manual cancel of rekeying to continue
-  (./safe curl DELETE sys/rekey/init); exitok $? 0
-
   now trying to rekey with a bad unseal key should error
   (run; ./safe rekey </dev/null >t/home/got 2>&1); exitok $? 1
   # the below sed is used, as earlier versions of vault had a bad error message, that later versions
@@ -2268,8 +2256,7 @@ EOF
   sed -i -e 's/must specified/must be specified/' t/home/got
   cat <<'EOF' > t/home/want ; diffok
 Vault rekey canceled successfully
-!! Error processing unseal key:
-["'key' must be specified in request body as JSON"]
+!! Key submission failed: no key provided
 EOF
 
   now after failures to rekey, the cancel command was sent to reset the rekey

--- a/vault/init.go
+++ b/vault/init.go
@@ -1,63 +1,18 @@
 package vault
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
+	"github.com/cloudfoundry-community/vaultkv"
 )
 
 func (v *Vault) Init(nkeys, threshold int) ([]string, string, error) {
-	if threshold > nkeys {
-		return nil, "", fmt.Errorf("cannot require %d/%d keys -- threshold is too high!", threshold, nkeys)
-	}
-
-	in := struct {
-		Keys      int `json:"secret_shares"`
-		Threshold int `json:"secret_threshold"`
-	}{
-		Keys:      nkeys,
+	out, err := v.client.InitVault(vaultkv.InitConfig{
+		Shares:    nkeys,
 		Threshold: threshold,
-	}
-	b, err := json.Marshal(&in)
+	})
+
 	if err != nil {
 		return nil, "", err
 	}
 
-	req, err := http.NewRequest("POST", v.url("/v1/sys/init"), bytes.NewReader(b))
-	if err != nil {
-		return nil, "", err
-	}
-
-	res, err := v.request(req)
-	if err != nil {
-		return nil, "", err
-	}
-
-	b, err = ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, "", err
-	}
-
-	var out struct {
-		Keys  []string `json:"keys_base64"`
-		Token string   `json:"root_token"`
-
-		Errors []string `json:"errors"`
-	}
-	err = json.Unmarshal(b, &out)
-	if err != nil {
-		return nil, "", err
-	}
-
-	if res.StatusCode != 200 {
-		if len(out.Errors) > 0 {
-			return nil, "", fmt.Errorf("%s", out.Errors[0])
-		} else {
-			return nil, "", fmt.Errorf("an unspecified error has occurred.")
-		}
-	}
-
-	return out.Keys, out.Token, nil
+	return out.Keys, out.RootToken, nil
 }

--- a/vault/rekey.go
+++ b/vault/rekey.go
@@ -1,105 +1,56 @@
 package vault
 
 import (
-	"encoding/json"
-	"io/ioutil"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/cloudfoundry-community/vaultkv"
 	"github.com/jhunt/go-ansi"
 	"github.com/starkandwayne/safe/prompt"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-type RekeyOpts struct {
-	SecretShares    int      `json:"secret_shares"`
-	SecretThreshold int      `json:"secret_threshold"`
-	PGPKeys         []string `json:"pgp_keys,omitempty"`
-	Backup          bool     `json:"backup,omitempty"`
-}
-
-type RekeyUpdateOpts struct {
-	Key   string `json:"key"`
-	Nonce string `json:"nonce"`
-}
-
-type RekeyResponse struct {
-	Errors   []string `json:"errors"`
-	Complete bool     `json:"complete"`
-	Progress int      `json:"progress"`
-	Required int      `json:"required"`
-	Nonce    string   `json:"nonce"`
-	Keys     []string `json:"keys"`
-}
-
-var shouldCancelRekey bool = false
 var termState *terminal.State
 
 func (v *Vault) cancelRekey() {
 	if termState != nil {
 		terminal.Restore(int(os.Stdin.Fd()), termState)
 	}
-	if shouldCancelRekey {
-		resp, err := v.Curl("DELETE", "sys/rekey/init", nil)
-		if err != nil {
-			ansi.Fprintf(os.Stderr, "Failed to cancel rekey process (you may need to manually cancel to rekey next time): %s\n", err.Error())
-			return
-		}
-		if resp.StatusCode >= 400 {
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				ansi.Fprintf(os.Stderr, "Unable to read body from rekey cancelation response (you may need to manually cancel to rekey next time): %s\n", err)
-				return
-			}
-			ansi.Fprintf(os.Stderr, "Failed to cancel rekey process (you may need to manually cancel to rekey next time): %s\n", body)
-			return
-		}
-		ansi.Fprintf(os.Stderr, "@y{Vault rekey canceled successfully}\n")
+	err := v.client.RekeyCancel()
+	if err != nil {
+		ansi.Fprintf(os.Stderr, "Failed to cancel rekey process: %s\n", err.Error())
+		return
 	}
+
+	ansi.Fprintf(os.Stderr, "@y{Vault rekey canceled successfully}\n")
 }
 
 func (v *Vault) ReKey(unsealKeyCount, numToUnseal int, pgpKeys []string) ([]string, error) {
+	err := v.client.RekeyCancel()
+	if err != nil {
+		return nil, fmt.Errorf("An error occurred when trying to cancel potentially preexisting rekey: %s", err)
+	}
+
 	backup := len(pgpKeys) > 0
-	rekeyOptions := RekeyOpts{
-		SecretShares:    unsealKeyCount,
-		SecretThreshold: numToUnseal,
-		PGPKeys:         pgpKeys,
-		Backup:          backup,
-	}
-	rekeyJSON, err := json.Marshal(rekeyOptions)
+	rekey, err := v.client.NewRekey(vaultkv.RekeyConfig{
+		Shares:    unsealKeyCount,
+		Threshold: numToUnseal,
+		PGPKeys:   pgpKeys,
+		Backup:    backup,
+	})
 	if err != nil {
-		return nil, err
-	}
-
-	resp, err := v.Curl("POST", "sys/rekey/init", rekeyJSON)
-	if err != nil {
-		return nil, ansi.Errorf("Error re-keying Vault: %s", err.Error())
-	}
-
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	rekeyResp := RekeyResponse{}
-	if err = json.Unmarshal(b, &rekeyResp); err != nil {
-		return nil, err
-	}
-
-	if rekeyResp.Errors != nil && len(rekeyResp.Errors) > 0 {
-		errorList, err := json.Marshal(rekeyResp.Errors)
-		if err != nil {
-			return nil, err
-		}
-		return nil, ansi.Errorf("Failed to start rekeying vault:\n%s", errorList)
-	}
-	if resp.StatusCode >= 400 {
-		return nil, ansi.Errorf("Failed to start rekeying vault: %s\nServer said:\n%s", resp.Status, string(b))
+		return nil, fmt.Errorf("An error occurred when starting a new rekey operation: %s", err)
 	}
 
 	// we successfully started a rekey, we should now cancel on failure, unless we finish rekeying
-	shouldCancelRekey = true
-	defer v.cancelRekey()
+	var shouldCancelRekey = true
+	defer func() {
+		if shouldCancelRekey {
+			v.cancelRekey()
+		}
+	}()
 	sighandler := make(chan os.Signal, 4)
 	signal.Ignore(os.Interrupt, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
 	signal.Notify(sighandler, os.Interrupt, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
@@ -116,44 +67,24 @@ func (v *Vault) ReKey(unsealKeyCount, numToUnseal int, pgpKeys []string) ([]stri
 			return nil, err
 		}
 	}
-	for rekeyResp.Progress < rekeyResp.Required && rekeyResp.Complete == false {
-		unsealKey := prompt.Secure("Unseal Key %d: ", rekeyResp.Progress+1)
-		updateOpts := RekeyUpdateOpts{
-			Key:   unsealKey,
-			Nonce: rekeyResp.Nonce,
-		}
-		updateOptsJSON, err := json.Marshal(updateOpts)
-		if err != nil {
-			return nil, err
-		}
-		resp, err = v.Curl("POST", "sys/rekey/update", updateOptsJSON)
-		if err != nil {
-			return nil, ansi.Errorf("Error validating the Vault rekey: %s", err.Error())
-		}
 
-		b, err = ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-		if err = json.Unmarshal(b, &rekeyResp); err != nil {
-			return nil, err
-		}
+	givenKeys := make([]string, rekey.Remaining())
 
-		if resp.StatusCode >= 400 {
-			// grab 'errors' from json, print it out
-			if rekeyResp.Errors != nil && len(rekeyResp.Errors) > 0 {
-				errStr, err := json.Marshal(rekeyResp.Errors)
-				if err != nil {
-					return nil, err
-				}
-				return nil, ansi.Errorf("Error processing unseal key:\n%s", errStr)
-			} else {
-				return nil, ansi.Errorf("Error processing unseal key:\n%s", string(b))
-			}
-		}
+	for i := 0; i < len(givenKeys); i++ {
+		givenKeys[i] = prompt.Secure("Unseal Key %d: ", rekey.State().Progress+1)
 	}
+
+	rekeyDone, err := rekey.Submit(givenKeys...)
+	if err != nil {
+		return nil, fmt.Errorf("Key submission failed: %s", err)
+	}
+	if !rekeyDone {
+		return nil, fmt.Errorf("The rekey did not finish (is somebody else trying to rekey at the same time?)")
+	}
+
 	// vault should be rekeyed by here, as our progress met the requirement
 	shouldCancelRekey = false
+	signal.Stop(sighandler)
 
-	return rekeyResp.Keys, nil
+	return rekey.Keys(), nil
 }

--- a/vault/renew.go
+++ b/vault/renew.go
@@ -1,23 +1,5 @@
 package vault
 
-import (
-	"fmt"
-	"net/http"
-)
-
 func (v *Vault) RenewLease() error {
-	req, err := http.NewRequest("POST", v.url("/v1/auth/token/renew-self"), nil)
-	if err != nil {
-		return err
-	}
-	res, err := v.request(req)
-	if err != nil {
-		return err
-	}
-
-	if res.StatusCode != 200 {
-		return fmt.Errorf("received HTTP %d response", res.StatusCode)
-	}
-
-	return nil
+	return v.client.TokenRenewSelf()
 }

--- a/vault/root.go
+++ b/vault/root.go
@@ -1,122 +1,33 @@
 package vault
 
 import (
-	"crypto/rand"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"strings"
 )
 
 func (v *Vault) NewRootToken(keys []string) (string, error) {
 	// cancel any previous generate-root attempts (get a new nonce!)
-	req, err := http.NewRequest("DELETE", v.url("/v1/sys/generate-root/attempt"), nil)
-	if err != nil {
-		return "", err
-	}
-	res, err := v.request(req)
-	if err != nil {
-		return "", err
-	}
-	if res.StatusCode != 204 {
-		return "", fmt.Errorf("failed to cancel previous generate-root attempt: HTTP %d response", res.StatusCode)
-	}
-
-	// generate a 16-byte one-time password, base64-encoded
-	otp := make([]byte, 16)
-	otp64 := make([]byte, 24) // does this need pre-alloc'd?
-	_, err = rand.Read(otp)
-	if err != nil {
-		return "", fmt.Errorf("unable to generate a one-time password: %s", err)
-	}
-	base64.StdEncoding.Encode(otp64, otp)
-
-	// initiate a new generate-root attempt, with our one-time password in play
-	req, err = http.NewRequest("PUT", v.url("/v1/sys/generate-root/attempt"), strings.NewReader(`{"otp":"`+string(otp64)+`"}`))
-	if err != nil {
-		return "", err
-	}
-	res, err = v.request(req)
-	if err != nil {
-		return "", err
-	}
-	if res.StatusCode != 200 {
-		return "", fmt.Errorf("failed to start a new generate-root attempt: HTTP %d response", res.StatusCode)
-	}
-
-	//  extract the nonce for this generate-root attempt go-round
-	var attempt struct {
-		Nonce string `json:"nonce"`
-	}
-	b, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return "", err
-	}
-	err = json.Unmarshal(b, &attempt)
+	err := v.client.GenerateRootCancel()
 	if err != nil {
 		return "", err
 	}
 
-	encoded := ""
-	for _, k := range keys {
-		// for each key, pass back the nonce, provide the key, and go!
-		payload := `{"key":"` + k + `","nonce":"` + attempt.Nonce + `"}`
-		req, err := http.NewRequest("PUT", v.url("/v1/sys/generate-root/update"), strings.NewReader(payload))
-		if err != nil {
-			return "", err
-		}
-		res, err := v.request(req)
-		if err != nil {
-			return "", err
-		}
-		if res.StatusCode != 200 {
-			return "", fmt.Errorf("failed to provide seal key to Vault: HTTP %d response", res.StatusCode)
-		}
-
-		// parse the response and save the encoded (token^otp) token
-		var out struct {
-			//encoded_root_token was changed to encoded_token in vault 0.9.0
-			EncodedToken     string `json:"encoded_token"`
-			EncodedRootToken string `json:"encoded_root_token"`
-			Complete         bool   `json:"complete"`
-		}
-		b, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return "", err
-		}
-		err = json.Unmarshal(b, &out)
-		if err != nil {
-			return "", err
-		}
-		if out.Complete {
-			encoded = out.EncodedToken
-			if out.EncodedRootToken != "" {
-				encoded = out.EncodedRootToken
-			}
-		}
+	genRoot, err := v.client.NewGenerateRoot()
+	if err != nil {
+		return "", err
 	}
 
-	if encoded == "" {
-		return "", fmt.Errorf("failed to generate new root token")
+	done, err := genRoot.Submit(keys...)
+	if err != nil {
+		return "", err
+	}
+	if !done {
+		return "", fmt.Errorf("Not enough keys were provided")
 	}
 
-	tok64 := []byte(encoded)
-	tok := make([]byte, base64.StdEncoding.DecodedLen(len(tok64)))
-	if len(tok64) != len(otp64) {
-		return "", fmt.Errorf("failed to decode new root token")
+	token, err := genRoot.RootToken()
+	if err != nil {
+		return "", err
 	}
 
-	base64.StdEncoding.Decode(tok, tok64)
-	for i := 0; i < 16; i++ {
-		tok[i] ^= otp[i]
-	}
-
-	return fmt.Sprintf("%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-		tok[0], tok[1], tok[2], tok[3],
-		tok[4], tok[5],
-		tok[6], tok[7],
-		tok[8], tok[9],
-		tok[10], tok[11], tok[12], tok[13], tok[14], tok[15]), nil
+	return token, nil
 }

--- a/vault/seal.go
+++ b/vault/seal.go
@@ -1,92 +1,43 @@
 package vault
 
 import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"regexp"
-	"strings"
+	"github.com/cloudfoundry-community/vaultkv"
 )
 
+//SealKeys returns the threshold for unsealing the vault
 func (v *Vault) SealKeys() (int, error) {
-	req, err := http.NewRequest("GET", v.url("/v1/sys/seal-status"), nil)
-	if err != nil {
-		return 0, err
-	}
-	res, err := v.request(req)
+	state, err := v.client.SealStatus()
 	if err != nil {
 		return 0, err
 	}
 
-	if res.StatusCode != 200 {
-		return 0, fmt.Errorf("received HTTP %d response (to /v1/sys/seal-status)", res.StatusCode)
-	}
-
-	b, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return 0, err
-	}
-
-	var data = struct {
-		Keys int `json:"t"`
-	}{}
-	err = json.Unmarshal(b, &data)
-	if err != nil {
-		return 0, err
-	}
-	return data.Keys, nil
+	return state.Threshold, nil
 }
 
 func (v *Vault) Seal() (bool, error) {
-	req, err := http.NewRequest("PUT", v.url("/v1/sys/seal"), nil)
-	if err != nil {
-		return false, err
-	}
-	res, err := v.request(req)
-	if err != nil {
-		return false, err
+	err := v.client.Seal()
+	ret := err == nil
+	if vaultkv.IsErrStandby(err) {
+		err = nil
 	}
 
-	if res.StatusCode == 500 {
-		if b, err := ioutil.ReadAll(res.Body); err == nil {
-			if matched, _ := regexp.Match("cannot seal when in standby mode", b); matched {
-				return false, nil
-			}
-		}
-	}
-	if res.StatusCode != 204 {
-		return false, fmt.Errorf("received HTTP %d response", res.StatusCode)
-	}
-	return true, nil
+	return ret, err
 }
 
 func (v *Vault) Unseal(keys []string) error {
-	req, err := http.NewRequest("PUT", v.url("/v1/sys/unseal"), strings.NewReader(`{"reset":true}`))
-	if err != nil {
-		return err
-	}
-	res, err := v.request(req)
+	err := v.client.ResetUnseal()
 	if err != nil {
 		return err
 	}
 
-	if res.StatusCode != 200 {
-		return fmt.Errorf("received HTTP %d response", res.StatusCode)
-	}
-
-	for _, k := range keys {
-		req, err := http.NewRequest("PUT", v.url("/v1/sys/unseal"), strings.NewReader(`{"key":"`+k+`"}`))
-		if err != nil {
-			return err
-		}
-		res, err := v.request(req)
+	for _, key := range keys {
+		state, err := v.client.Unseal(key)
 		if err != nil {
 			return err
 		}
 
-		if res.StatusCode != 200 {
-			return fmt.Errorf("received HTTP %d response", res.StatusCode)
+		if state.Sealed == false {
+			break
 		}
 	}
 	return nil

--- a/vault/strongbox.go
+++ b/vault/strongbox.go
@@ -5,17 +5,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"regexp"
 )
 
 func (v *Vault) Strongbox() (map[string]string, error) {
 	m := make(map[string]string)
 
-	u, err := url.Parse(v.URL)
-	if err != nil {
-		return m, err
-	}
+	u := *v.client.VaultURL
 
 	c := &http.Client{}
 	re := regexp.MustCompile(`:[0-9]+$`)

--- a/vendor/github.com/cloudfoundry-community/vaultkv/LICENSE
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>

--- a/vendor/github.com/cloudfoundry-community/vaultkv/README.md
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/README.md
@@ -1,0 +1,46 @@
+# vaultkv
+
+## How to Use
+
+This is a GoDoc: https://godoc.org/github.com/cloudfoundry-community/vaultkv
+
+If you want to do anything with this library, then you'll need to make a
+Client object. The Client object will need, at the very least, its `VaultURI`
+member populated. AuthToken should be set to your bearer token for Vault. If
+you need a bearer token created from some other auth method, you can call one
+of the AuthX functions (currently, we support Github, LDAP, and Userpass). An
+http client can be optionally provided (if not, then `http.DefaultClient`
+will be used). If you would like to see information about the requests and
+responses, then you can optionally provide an io.Writer for trace logs to be
+streamed to.
+
+```go
+func main() {
+  vault := &vaultkv.Client{
+  AuthToken: "01234567-89ab-cdef-0123-456789abcdef",
+    VaultURL: vaultURI,
+    Client: &http.Client{
+      Transport: &http.Transport{
+        TLSClientConfig: &tls.Config{
+          InsecureSkipVerify: true,
+        },
+      },
+    },
+    Trace: os.Stdout,
+  }
+
+  output := struct{
+    Bar string `json:"bar"`
+  }{}
+  err := vault.Get("secret/foo", &output)
+  if err != nil {
+    os.Exit(1)
+  }
+
+  fmt.Printf("output.Bar is `%s'\n", output.Bar)
+}
+```
+
+## Testing
+
+Run `./test` in the base directory to test all supported Vault versions. Run `./test latest` to test only the latest supported version of Vault.

--- a/vendor/github.com/cloudfoundry-community/vaultkv/auth.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/auth.go
@@ -1,0 +1,107 @@
+package vaultkv
+
+import "fmt"
+
+//AuthOutput is the general structure as returned by AuthX functions. The
+//Metadata member type is determined by the specific Auth function. Note that
+//the Vault must be initialized and unsealed in order to use authentication
+//endpoints.
+type AuthOutput struct {
+	LeaseID       string `json:"lease_id"`
+	Renewable     bool   `json:"renewable"`
+	LeaseDuration int    `json:"lease_duration"`
+	Auth          struct {
+		ClientToken string   `json:"client_token"`
+		Accessor    string   `json:"accessor"`
+		Policies    []string `json:"policies"`
+	}
+	//Metadata's internal structure is dependent on the auth type
+	Metadata interface{} `json:"metadata"`
+}
+
+//AuthGithubMetadata is the metadata member set by AuthGithub.
+type AuthGithubMetadata struct {
+	Username     string `json:"username"`
+	Organization string `json:"org"`
+}
+
+//AuthGithub submits the given accessToken to the github auth endpoint, checking
+// it against configurations for Github organizations. If the accessToken
+// belongs to an authorized account, then the AuthOutput object is returned, and
+// this client's AuthToken is set to the returned token.
+func (v *Client) AuthGithub(accessToken string) (ret *AuthOutput, err error) {
+	ret = &AuthOutput{Metadata: AuthGithubMetadata{}}
+	err = v.doRequest(
+		"POST",
+		"/auth/github/login",
+		struct {
+			Token string `json:"token"`
+		}{Token: accessToken},
+		&ret,
+	)
+
+	if err == nil {
+		v.AuthToken = ret.Auth.ClientToken
+	}
+
+	return
+}
+
+//AuthLDAPMetadata is the metadata member set by AuthLDAP
+type AuthLDAPMetadata struct {
+	Username string `json:"username"`
+}
+
+//AuthLDAP submits the given username and password to the LDAP auth endpoint,
+//checking it against existing LDAP auth configurations. If auth is successful,
+//then the AuthOutput object is returned, and this client's AuthToken is set to
+//the returned token.
+func (v *Client) AuthLDAP(username, password string) (ret *AuthOutput, err error) {
+	ret = &AuthOutput{Metadata: AuthLDAPMetadata{}}
+	err = v.doRequest(
+		"POST",
+		fmt.Sprintf("/auth/ldap/login/%s", username),
+		struct {
+			Password string `json:"password"`
+		}{Password: password},
+		&ret,
+	)
+
+	if err == nil {
+		v.AuthToken = ret.Auth.ClientToken
+	}
+
+	return
+}
+
+//AuthUserpassMetadata is the metadata member set by AuthUserpass
+type AuthUserpassMetadata struct {
+	Username string `json:"username"`
+}
+
+//AuthUserpass submits the given username and password to the userpass auth
+//endpoint. If a username with that password exists, then the AuthOutput object
+//is returned, and this client's AuthToken is set to the returned token.
+func (v *Client) AuthUserpass(username, password string) (ret *AuthOutput, err error) {
+	ret = &AuthOutput{Metadata: AuthUserpassMetadata{}}
+	err = v.doRequest(
+		"POST",
+		fmt.Sprintf("/auth/userpass/login/%s", username),
+		struct {
+			Password string `json:"password"`
+		}{Password: password},
+		&ret,
+	)
+
+	if err == nil {
+		v.AuthToken = ret.Auth.ClientToken
+	}
+
+	return
+}
+
+//TokenRenewSelf takes the token in the Client object and attempts to renew its
+// lease.
+func (v *Client) TokenRenewSelf() (err error) {
+	return v.doRequest("POST", "/auth/token/renew-self", nil, nil)
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/client.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/client.go
@@ -1,0 +1,133 @@
+//Package vaultkv provides a client with functions that make API calls that a user of
+// Vault may commonly want.
+package vaultkv
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+//Client provides functions that access and abstract the Vault API.
+// VaultURL must be set to the for the client to work. Only Vault versions
+// 0.6.5 and above are tested to work with this client.
+type Client struct {
+	AuthToken string
+	VaultURL  *url.URL
+	//If Client is nil, http.DefaultClient will be used
+	Client *http.Client
+	//If Trace is non-nil, information about HTTP requests will be given into the
+	//Writer.
+	Trace io.Writer
+}
+
+type vaultResponse struct {
+	Data interface{} `json:"data"`
+	//There's totally more to the response, but this is all I care about atm.
+}
+
+//URL encoded values can be given as a *url.Values as "input" when performing
+// a GET call
+func (v *Client) doRequest(
+	method, path string,
+	input interface{},
+	output interface{}) error {
+
+	u := *v.VaultURL
+	u.Path = fmt.Sprintf("/v1/%s", strings.Trim(path, "/"))
+	if u.Port() == "" {
+		u.Host = fmt.Sprintf("%s:8200", u.Host)
+	}
+
+	var query url.Values
+	var body io.Reader
+	if input != nil {
+		if strings.ToUpper(method) == "GET" {
+			//Input has to be a url.Values
+			query = input.(url.Values)
+		} else {
+			body = &bytes.Buffer{}
+			err := json.NewEncoder(body.(*bytes.Buffer)).Encode(input)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	resp, err := v.Curl(method, path, query, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		return v.parseError(resp)
+	}
+
+	if output != nil && resp.StatusCode == 200 {
+		err = json.NewDecoder(resp.Body).Decode(output)
+	}
+
+	return err
+}
+
+//Curl takes the given path, prepends <VaultURL>/v1/ to it, and makes the request
+// with the remainder of the given parameters. Errors returned only reflect
+// transport errors, not HTTP semantic errors
+func (v *Client) Curl(method string, path string, urlQuery url.Values, body io.Reader) (*http.Response, error) {
+	//Setup URL
+	u := *v.VaultURL
+	u.Path = fmt.Sprintf("/v1/%s", strings.Trim(path, "/"))
+	if u.Port() == "" {
+		u.Host = fmt.Sprintf("%s:8200", u.Host)
+	}
+	u.RawQuery = urlQuery.Encode()
+
+	//Do the request
+	req, err := http.NewRequest(method, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	if v.Trace != nil {
+		dump, _ := httputil.DumpRequest(req, true)
+		v.Trace.Write([]byte(fmt.Sprintf("Request:\n%s\n", dump)))
+	}
+
+	token := v.AuthToken
+	if token == "" {
+		token = "01234567-89ab-cdef-0123-456789abcdef"
+	}
+	req.Header.Set("X-Vault-Token", token)
+
+	client := v.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	if client.CheckRedirect == nil {
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) > 10 {
+				return fmt.Errorf("Stopped after 10 redirects")
+			}
+			req.Header.Set("X-Vault-Token", token)
+			return nil
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, &ErrTransport{message: err.Error()}
+	}
+
+	if v.Trace != nil {
+		dump, _ := httputil.DumpResponse(resp, true)
+		v.Trace.Write([]byte(fmt.Sprintf("Response:\n%s\n", dump)))
+	}
+
+	return resp, nil
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/errors.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/errors.go
@@ -1,0 +1,174 @@
+package vaultkv
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+//ErrBadRequest represents 400 status codes that are returned from the API.
+//See: your fault.
+type ErrBadRequest struct {
+	message string
+}
+
+func (e *ErrBadRequest) Error() string {
+	return e.message
+}
+
+//IsBadRequest returns true if the error is an ErrBadRequest
+func IsBadRequest(err error) bool {
+	_, is := err.(*ErrBadRequest)
+	return is
+}
+
+//ErrForbidden represents 403 status codes returned from the API. This could be
+// if your auth is wrong or expired, or you simply don't have access to do the
+// particular thing you're trying to do. Check your privilege.
+type ErrForbidden struct {
+	message string
+}
+
+func (e *ErrForbidden) Error() string {
+	return e.message
+}
+
+//IsForbidden returns true if the error is an ErrForbidden
+func IsForbidden(err error) bool {
+	_, is := err.(*ErrForbidden)
+	return is
+}
+
+//ErrNotFound represents 404 status codes returned from the API. This could be
+// either that the thing you're looking for doesn't exist, or in some cases
+// that you don't have access to the thing you're looking for and that Vault is
+// hiding it from you.
+type ErrNotFound struct {
+	message string
+}
+
+func (e *ErrNotFound) Error() string {
+	return e.message
+}
+
+//IsNotFound returns true if the error is an ErrNotFound
+func IsNotFound(err error) bool {
+	_, is := err.(*ErrNotFound)
+	return is
+}
+
+//ErrStandby is only returned from Health() if standbyok is set to false and the
+// node you're querying is a standby.
+type ErrStandby struct {
+	message string
+}
+
+func (e *ErrStandby) Error() string {
+	return e.message
+}
+
+//IsErrStandby returns true if the error is an ErrStandby
+func IsErrStandby(err error) bool {
+	_, is := err.(*ErrStandby)
+	return is
+}
+
+//ErrInternalServer represents 500 status codes that are returned from the API.
+//See: their fault.
+type ErrInternalServer struct {
+	message string
+}
+
+func (e *ErrInternalServer) Error() string {
+	return e.message
+}
+
+//IsInternalServer returns true if the error is an ErrInternalServer
+func IsInternalServer(err error) bool {
+	_, is := err.(*ErrInternalServer)
+	return is
+}
+
+//ErrSealed represents the 503 status code that is returned by Vault most
+// commonly if the Vault is currently sealed, but could also represent the Vault
+// being in a maintenance state.
+type ErrSealed struct {
+	message string
+}
+
+func (e *ErrSealed) Error() string {
+	return e.message
+}
+
+//IsSealed returns true if the error is an ErrSealed
+func IsSealed(err error) bool {
+	_, is := err.(*ErrSealed)
+	return is
+}
+
+//ErrUninitialized represents a 503 status code being returned and the Vault
+//being uninitialized.
+type ErrUninitialized struct {
+	message string
+}
+
+func (e *ErrUninitialized) Error() string {
+	return e.message
+}
+
+//IsUninitialized returns true if the error is an ErrUninitialized
+func IsUninitialized(err error) bool {
+	_, is := err.(*ErrUninitialized)
+	return is
+}
+
+//ErrTransport is returned if an error was encountered trying to reach the API,
+// as opposed to an error from the API, is returned
+type ErrTransport struct {
+	message string
+}
+
+func (e *ErrTransport) Error() string {
+	return e.message
+}
+
+//IsTransport returns true if the error is an ErrTransport
+func IsTransport(err error) bool {
+	_, is := err.(*ErrTransport)
+	return is
+}
+
+type apiError struct {
+	Errors []string `json:"errors"`
+}
+
+func (v *Client) parseError(r *http.Response) (err error) {
+	errorsStruct := apiError{}
+	err = json.NewDecoder(r.Body).Decode(&errorsStruct)
+	if err != nil {
+		return err
+	}
+	errorMessage := strings.Join(errorsStruct.Errors, "\n")
+
+	switch r.StatusCode {
+	case 400:
+		err = &ErrBadRequest{message: errorMessage}
+	case 403:
+		err = &ErrForbidden{message: errorMessage}
+	case 404:
+		err = &ErrNotFound{message: errorMessage}
+	case 500:
+		err = &ErrInternalServer{message: errorMessage}
+	case 503:
+		err = v.parse503(errorMessage)
+	default:
+		err = errors.New(errorMessage)
+	}
+
+	return
+}
+
+func (v *Client) parse503(message string) (err error) {
+	return v.Health(true)
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/kv.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/kv.go
@@ -1,0 +1,68 @@
+package vaultkv
+
+import (
+	"fmt"
+	"reflect"
+)
+
+//Get retrieves the secret at the given path and unmarshals it into the given
+//output object using the semantics of encoding/json.Unmarshal. If the object
+//is nil, an unmarshal will not be attempted (this can be used to check for
+//existence). If the object could not be unmarshalled into, the resultant error
+//is returned. Example path would be /secret/foo, if Key/Value backend were
+//mounted at "/secret". The Vault must be unsealed and initialized for this
+//endpoint to work. No assumptions are made about the mounting point of your
+//Key/Value backend.
+func (v *Client) Get(path string, output interface{}) error {
+	if output != nil &&
+		reflect.ValueOf(output).Kind() != reflect.Ptr {
+		return fmt.Errorf("Get output target must be a pointer if non-nil")
+	}
+
+	err := v.doRequest("GET", path, nil, &vaultResponse{Data: output})
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+//List returns the list of paths nested directly under the given path. If this
+//is not a "directory" for any paths, then ErrNotFound is returned. In the list
+//of paths returned on success, if a path ends with a slash, then it is also a
+//"directory". The Vault must be unsealed and initialized for this endpoint to
+//work. No assumptions are made about the mounting point of your Key/Value
+//backend.
+func (v *Client) List(path string) ([]string, error) {
+	ret := []string{}
+
+	err := v.doRequest("LIST", path, nil, &vaultResponse{
+		Data: &struct {
+			Keys *[]string `json:"keys"`
+		}{
+			Keys: &ret,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, err
+}
+
+//Set puts the values in the given map at the given path. The keys in the map
+//become the keys at the path, and the values in the map become the values of
+//those keys. The Vault must be unsealed and initialized for this endpoint to
+//work. No assumptions are made about the mounting point of your Key/Value
+//backend.
+func (v *Client) Set(path string, values map[string]string) error {
+	//TODO: This function should be changed to accept a map[string]interface{}
+	//Then tests should be written for cases other than map[string]string
+	return v.doRequest("PUT", path, &values, nil)
+}
+
+//Delete attempts to delete the value at the specified path. No error is
+//returned if there is already no value at the given path.
+func (v *Client) Delete(path string) error {
+	return v.doRequest("DELETE", path, nil, nil)
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/kv2.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/kv2.go
@@ -1,0 +1,325 @@
+package vaultkv
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+//IsKVv2Mount returns true if the mount is a version 2 KV mount and false
+//otherwise. This will also simply return false if no mount exists at the given
+//mount point or if the Vault is too old to have the API endpoint to look for
+//the mount. If a different API error occurs, it will be propagated out.
+func (c *Client) IsKVv2Mount(path string) (bool, error) {
+	output := struct {
+		Type    string `json:"type"`
+		Options struct {
+			Version string `json:"version"`
+		} `json:"options"`
+	}{}
+
+	err := c.doRequest(
+		"GET",
+		fmt.Sprintf("/sys/internal/ui/mounts/%s", strings.TrimLeft(path, "/")),
+		nil, &output)
+	if err != nil {
+		//If we got a 404, either the mount doesn't exist or this version of Vault
+		// is too old to possibly have a v2 backend
+		if _, is404 := err.(*ErrNotFound); is404 {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if output.Type != "kv" {
+		return false, nil
+	}
+
+	version, err := strconv.ParseUint(output.Options.Version, 10, 64)
+	if err != nil {
+		return false, nil
+	}
+
+	return version == 2, nil
+}
+
+func splitMount(path string) (mount string, subpath string) {
+	path = strings.TrimLeft(path, "/")
+	splits := strings.SplitN(path, "/", 2)
+	mount = splits[0]
+	if len(splits) > 1 {
+		subpath = splits[1]
+	}
+
+	subpath = fmt.Sprintf("/%s", strings.TrimLeft(subpath, "/"))
+	return
+}
+
+//V2Version is information about a version of a secret. The DeletedAt member
+// will be nil to signify that a version is not deleted. Take note of the
+// difference between "deleted" and "destroyed" - a deletion simply marks a
+// secret as deleted, preventing it from being read. A destruction actually
+// removes the data from storage irrevocably.
+type V2Version struct {
+	CreatedAt time.Time
+	DeletedAt *time.Time
+	Destroyed bool
+	Version   uint
+}
+
+type v2VersionAPI struct {
+	CreatedTime  string `json:"created_time"`
+	DeletionTime string `json:"deletion_time"`
+	Destroyed    bool   `json:"destroyed"`
+	Version      uint   `json:"version"`
+}
+
+func (v v2VersionAPI) Parse() V2Version {
+	ret := V2Version{
+		Destroyed: v.Destroyed,
+		Version:   v.Version,
+	}
+
+	//Parse those times
+	ret.CreatedAt, _ = time.Parse(time.RFC3339Nano, v.CreatedTime)
+	tmpDeletion, err := time.Parse(time.RFC3339Nano, v.DeletionTime)
+	if err == nil {
+		ret.DeletedAt = &tmpDeletion
+	}
+
+	return ret
+}
+
+//V2GetOpts are options to specify in a V2Get request.
+type V2GetOpts struct {
+	// Version is the version of the resource to retrieve. Setting this to zero (or
+	// not setting it at all) will retrieve the latest version
+	Version uint
+}
+
+//V2Get will get a secret from the given path in a KV version 2 secrets backend.
+//If the secret is at "/bar" in the backend mounted at "foo", then the path
+//should be "foo/bar". The response will be decoded into the item pointed to
+//by output using encoding/json.Unmarshal semantics. The version to retrieve
+//can be selected by setting Version in the V2GetOpts struct at opts.
+func (c *Client) V2Get(path string, output interface{}, opts *V2GetOpts) (meta V2Version, err error) {
+	if output != nil &&
+		reflect.ValueOf(output).Kind() != reflect.Ptr {
+		err = fmt.Errorf("V2Get output target must be a pointer if non-nil")
+		return
+	}
+
+	type outputData struct {
+		Metadata v2VersionAPI `json:"metadata"`
+		Data     interface{}  `json:"data"`
+	}
+
+	unmarshalInto := &struct {
+		Data outputData `json:"data"`
+	}{
+		Data: outputData{
+			Metadata: v2VersionAPI{},
+			Data:     output,
+		},
+	}
+
+	query := url.Values{}
+	if opts != nil {
+		query.Add("version", strconv.FormatUint(uint64(opts.Version), 10))
+	}
+
+	mount, subpath := splitMount(path)
+	path = fmt.Sprintf("%s/data%s", mount, subpath)
+	err = c.doRequest("GET", path, query, unmarshalInto)
+	if err != nil {
+		return
+	}
+
+	meta = unmarshalInto.Data.Metadata.Parse()
+	return
+}
+
+//V2SetOpts are options that can be specified to a V2Set call
+type V2SetOpts struct {
+	//CAS provides a check-and-set version number. If this is set to zero, then
+	// the value will only be written if the key does not yet exist. If the CAS
+	//number is non-zero, then this will only be written if the current version
+	//for your this secret matches the CAS value.
+	CAS *uint `json:"cas,omitempty"`
+}
+
+//WithCAS returns a pointer to a new V2SetOpts with the CAS value set to the
+//given value. If i is zero, then the value will only be written if the key
+//does not exist. If i is non-zero, then the value will only be written if the
+//currently existing version matches i. Not calling CAS will result in no
+//restriction on writing. If the mount is set up for requiring CAS, then not
+//setting CAS with this function a valid number will result in a failure when
+//attempting to write.
+func (s V2SetOpts) WithCAS(i uint) *V2SetOpts {
+	s.CAS = new(uint)
+	*s.CAS = i
+	return &s
+}
+
+//V2Set uses encoding/json.Marshal on the object given in values to encode
+// the secret as JSON, and writes it to the path given. Populate ops to use the
+// check-and-set functionality. Returns the metadata about the written secret
+// if the write is successful.
+func (c *Client) V2Set(path string, values interface{}, opts *V2SetOpts) (meta V2Version, err error) {
+	input := struct {
+		Options *V2SetOpts  `json:"options,omitempty"`
+		Data    interface{} `json:"data"`
+	}{
+		Options: opts,
+		Data:    &values,
+	}
+
+	output := struct {
+		Data v2VersionAPI `json:"data"`
+	}{
+		Data: v2VersionAPI{},
+	}
+
+	mount, subpath := splitMount(path)
+	path = fmt.Sprintf("%s/data%s", mount, subpath)
+
+	err = c.doRequest("PUT", path, &input, &output)
+	if err != nil {
+		return
+	}
+
+	meta = output.Data.Parse()
+	return
+}
+
+//V2DeleteOpts are options that can be provided to a V2Delete call.
+type V2DeleteOpts struct {
+	Versions []uint `json:"versions"`
+}
+
+//V2Delete marks a secret version at the given path as deleted. If opts is not
+// provided or the Versions slice therein is left nil, the latest version is
+// deleted. Otherwise, the specified versions are deleted. Note that the deleted
+// data from this call is recoverable from a call to V2Undelete.
+func (c *Client) V2Delete(path string, opts *V2DeleteOpts) error {
+	method := "DELETE"
+	mount, subpath := splitMount(path)
+	path = fmt.Sprintf("%s/data%s", mount, subpath)
+
+	if opts != nil && len(opts.Versions) > 0 {
+		method = "POST"
+		path = fmt.Sprintf("%s/delete%s", mount, subpath)
+	} else {
+		opts = nil
+	}
+
+	return c.doRequest(method, path, opts, nil)
+}
+
+//V2Undelete marks the specified versions at the specified paths as not deleted.
+func (c *Client) V2Undelete(path string, versions []uint) error {
+	mount, subpath := splitMount(path)
+	path = fmt.Sprintf("%s/undelete%s", mount, subpath)
+	return c.doRequest("POST", path, struct {
+		Versions []uint `json:"versions"`
+	}{
+		Versions: versions,
+	}, nil)
+}
+
+//V2Destroy permanently deletes the specified versions at the specified path.
+func (c *Client) V2Destroy(path string, versions []uint) error {
+	mount, subpath := splitMount(path)
+	path = fmt.Sprintf("%s/destroy%s", mount, subpath)
+	return c.doRequest("POST", path, struct {
+		Versions []uint `json:"versions"`
+	}{
+		Versions: versions,
+	}, nil)
+}
+
+//V2DestroyMetadata permanently destroys all secret versions and all metadata
+// associated with the secret at the specified path.
+func (c *Client) V2DestroyMetadata(path string) error {
+	mount, subpath := splitMount(path)
+	path = fmt.Sprintf("%s/metadata%s", mount, subpath)
+	return c.doRequest("DELETE", path, nil, nil)
+}
+
+//V2Metadata is the metadata associated with a secret
+type V2Metadata struct {
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	//CurrentVersion is the highest version number that has been created for this
+	//secret. Deleteing or destroying the highest version does not change this
+	//number.
+	CurrentVersion uint
+	OldestVersion  uint
+	MaxVersions    uint
+	Versions       []V2Version
+}
+
+type v2MetadataAPI struct {
+	Data struct {
+		CreatedTime    string                  `json:"created_time"`
+		CurrentVersion uint                    `json:"current_version"`
+		MaxVersions    uint                    `json:"max_versions"`
+		OldestVersion  uint                    `json:"oldest_version"`
+		UpdatedTime    string                  `json:"updated_time"`
+		Versions       map[string]v2VersionAPI `json:"versions"`
+	} `json:"data"`
+}
+
+//Version returns the version with the given number in the metadata as a
+//V2Version object , if present. If no version with that number is present, an
+//error is returned.
+func (m V2Metadata) Version(number uint) (version V2Version, err error) {
+	if number > uint(len(m.Versions)) || number < 1 {
+		err = fmt.Errorf("That version does not exist in the metadata")
+		return
+	}
+	version = m.Versions[number-1]
+	return
+}
+
+func (m v2MetadataAPI) Parse() V2Metadata {
+	ret := V2Metadata{
+		CurrentVersion: m.Data.CurrentVersion,
+		MaxVersions:    m.Data.MaxVersions,
+		OldestVersion:  m.Data.OldestVersion,
+	}
+
+	ret.CreatedAt, _ = time.Parse(time.RFC3339Nano, m.Data.CreatedTime)
+	ret.UpdatedAt, _ = time.Parse(time.RFC3339Nano, m.Data.UpdatedTime)
+
+	for number, metadata := range m.Data.Versions {
+		toAdd := metadata.Parse()
+		version64, _ := strconv.ParseUint(number, 10, 64)
+		toAdd.Version = uint(version64)
+		ret.Versions = append(ret.Versions, toAdd)
+	}
+
+	sort.Slice(ret.Versions,
+		func(i, j int) bool { return ret.Versions[i].Version < ret.Versions[j].Version },
+	)
+
+	return ret
+}
+
+//V2GetMetadata gets the metadata associatedw with the secret at the specified
+// path.
+func (c *Client) V2GetMetadata(path string) (meta V2Metadata, err error) {
+	mount, subpath := splitMount(path)
+	path = fmt.Sprintf("%s/metadata%s", mount, subpath)
+	output := v2MetadataAPI{}
+	err = c.doRequest("GET", path, nil, &output)
+	if err != nil {
+		return
+	}
+	meta = output.Parse()
+	return
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/mount.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/mount.go
@@ -1,0 +1,199 @@
+package vaultkv
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	//MountTypeGeneric is what the key value backend was called prior to 0.8.0
+	MountTypeGeneric = "generic"
+	//MountTypeKV is the type string to get a Key Value backend
+	MountTypeKV = "kv"
+)
+
+//Mount represents a backend mounted at a point in Vault.
+type Mount struct {
+	//The type of mount at this point
+	Type        string
+	Description string
+	Config      *MountConfig
+	Options     map[string]interface{}
+}
+
+//MountConfig specifies configuration options given when initializing a backend.
+type MountConfig struct {
+	DefaultLeaseTTL time.Duration
+	MaxLeaseTTL     time.Duration
+	PluginName      string
+	ForceNoCache    bool
+}
+
+type mountListAPI struct {
+	Type        string                 `json:"type"`
+	Description string                 `json:"description"`
+	Config      mountConfigListAPI     `json:"config"`
+	Options     map[string]interface{} `json:"options"`
+}
+
+func (m mountListAPI) Parse() Mount {
+	return Mount{
+		Type:        m.Type,
+		Description: m.Description,
+		Config:      m.Config.Parse(),
+		Options:     m.Options,
+	}
+}
+
+type mountConfigListAPI struct {
+	//time in seconds
+	DefaultLeaseTTL int    `json:"default_lease_ttl"`
+	MaxLeaseTTL     int    `json:"max_lease_ttl"`
+	PluginName      string `json:"plugin_name"`
+	ForceNoCache    bool   `json:"force_no_cache"`
+}
+
+func (m mountConfigListAPI) Parse() *MountConfig {
+	return &MountConfig{
+		DefaultLeaseTTL: time.Duration(m.DefaultLeaseTTL) * time.Second,
+		MaxLeaseTTL:     time.Duration(m.MaxLeaseTTL) * time.Second,
+		PluginName:      m.PluginName,
+		ForceNoCache:    m.ForceNoCache,
+	}
+}
+
+type mountConfigEnableAPI struct {
+	DefaultLeaseTTL string `json:"default_lease_ttl,omitempty"`
+	MaxLeaseTTL     string `json:"max_lease_ttl,omitempty"`
+	PluginName      string `json:"plugin_name,omitempty"`
+	ForceNoCache    bool   `json:"force_no_cache,omitempty"`
+}
+
+func newMountConfigEnableAPI(conf *MountConfig) *mountConfigEnableAPI {
+	if conf == nil {
+		return nil
+	}
+
+	return &mountConfigEnableAPI{
+		DefaultLeaseTTL: func() string {
+			if conf.DefaultLeaseTTL == 0 {
+				return ""
+			}
+			return conf.DefaultLeaseTTL.String()
+		}(),
+		MaxLeaseTTL: func() string {
+			if conf.MaxLeaseTTL == 0 {
+				return ""
+			}
+			return conf.DefaultLeaseTTL.String()
+		}(),
+		PluginName:   conf.PluginName,
+		ForceNoCache: conf.ForceNoCache,
+	}
+}
+
+//ListMounts queries the Vault backend for a list of active mounts that can
+// be seen with the current authentication token. It is returned as a map
+// of mount points to mount information.
+func (c *Client) ListMounts() (map[string]Mount, error) {
+	output := map[string]interface{}{}
+	//Prior to 1.10, the mount names were top level keys. Then, they duplicated the
+	// information into "data" with other metadata in the top level keys. So we need
+	// to check if the data key is there (and isn't just a mount name)
+	err := c.doRequest("GET", "/sys/mounts", nil, &output)
+	if err != nil {
+		return nil, err
+	}
+
+	var mounts map[string]mountListAPI
+	if dataKey, ok := output["data"]; ok {
+		mounts = getMountList(dataKey)
+	}
+
+	if mounts == nil {
+		mounts := getMountList(output)
+		if mounts == nil {
+			return nil, fmt.Errorf("Could not parse mount list")
+		}
+	}
+
+	ret := map[string]Mount{}
+	for k, v := range mounts {
+		ret[strings.TrimRight(k, "/")] = v.Parse()
+	}
+
+	return ret, err
+}
+
+func getMountList(candidate interface{}) map[string]mountListAPI {
+	//check if data key is not a mount name
+	b, err := json.Marshal(&candidate)
+	if err != nil {
+		return nil
+	}
+
+	tmpOutput := map[string]mountListAPI{}
+	err = json.Unmarshal(b, &tmpOutput)
+	if err != nil {
+		return nil
+	}
+
+	return tmpOutput
+}
+
+//KVMountOptions is a map[string]interface{} that can be given as the options
+//when mounting a backend. It has Version manipulation functions to make life
+//easier.
+type KVMountOptions map[string]interface{}
+
+//GetVersion retruns the version held in the KVMountOptions object
+func (o KVMountOptions) GetVersion() int {
+	if o == nil {
+		return 1
+	}
+
+	version, hasExplicitVersion := o["version"]
+	if !hasExplicitVersion {
+		return 1
+	}
+
+	vStr := version.(string)
+	ret, _ := strconv.Atoi(vStr)
+	return ret
+}
+
+//WithVersion returns a new KVMountOptions object with the given version
+func (o KVMountOptions) WithVersion(version int) KVMountOptions {
+	if o == nil {
+		o = make(map[string]interface{}, 1)
+	}
+
+	o["version"] = strconv.Itoa(version)
+	return o
+}
+
+//EnableSecretsMount mounts a secrets backend at the given path, configured with
+// the given Mount configuration.
+func (c *Client) EnableSecretsMount(path string, config Mount) error {
+	input := struct {
+		Type        string                `json:"type"`
+		Description string                `json:"description"`
+		Config      *mountConfigEnableAPI `json:"config,omitempty"`
+		Options     interface{}           `json:"options,omitempty"`
+	}{
+		Type:        config.Type,
+		Description: config.Description,
+		Config:      newMountConfigEnableAPI(config.Config),
+		Options:     config.Options,
+	}
+
+	return c.doRequest("POST", fmt.Sprintf("/sys/mounts/%s", path), &input, nil)
+}
+
+//DisableSecretsMount deletes the mount at the given path.
+func (c *Client) DisableSecretsMount(path string) error {
+	return c.doRequest("DELETE", fmt.Sprintf("/sys/mounts/%s", path), nil, nil)
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/rekey.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/rekey.go
@@ -1,0 +1,228 @@
+package vaultkv
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+//Rekey represents a rekey operation currently in progress in the Vault. This
+// wraps an otherwise cumbersome rekey API. Remaining() can be called to see
+// how many keys are still required by the rekey, and then those many keys
+// can be sent through one or more calls to Submit(). This should be created
+// through a call to NewRekey or CurrentRekey. Using an uninitialized Rekey
+// struct will lead to undefined behavior.
+type Rekey struct {
+	client *Client
+	state  RekeyState
+	keys   []string
+}
+
+//RekeyConfig is given to NewRekey to configure the parameters of the rekey
+//operation to be started.
+type RekeyConfig struct {
+	Shares    int      `json:"secret_shares"`
+	Threshold int      `json:"secret_threshold"`
+	PGPKeys   []string `json:"pgp_keys,omitempty"`
+	Backup    bool     `json:"backup,omitempty"`
+}
+
+//RekeyState gives the state of the rekey operation as of the last call to
+//Submit, NewRekey, or CurrentRekey.
+type RekeyState struct {
+	Started          bool   `json:"started"`
+	Nonce            string `json:"nonce"`
+	PendingThreshold int    `json:"t"`
+	PendingShares    int    `json:"n"`
+	//The number of keys given so far in this rekey operation
+	Progress int `json:"progress"`
+	//The total number of keys needed for this rekey operation
+	Required        int      `json:"required"`
+	PGPFingerprints []string `json:"pgp_fingerprints"`
+	Backup          bool     `json:"backup"`
+}
+
+//NewRekey will start a new rekey operation. If successful, a *Rekey is
+//returned containing the necessary state for submitting keys for this rekey
+//operation.
+func (v *Client) NewRekey(conf RekeyConfig) (*Rekey, error) {
+	err := v.rekeyStart(conf)
+	if err != nil {
+		err = v.correct500Error(err)
+		return nil, err
+	}
+
+	return v.CurrentRekey()
+}
+
+//CurrentRekey returns a *Rekey with the state necessary to continue a rekey
+// operation if one is in progress. If no rekey is in progress, *ErrNotFound
+// is returned and no *Rekey is returned.
+func (v *Client) CurrentRekey() (*Rekey, error) {
+	var state RekeyState
+	err := v.doSysRequest("GET", "/sys/rekey/init", nil, &state)
+	if err != nil {
+		err = v.correct500Error(err)
+		return nil, err
+	}
+
+	if !state.Started {
+		return nil, &ErrNotFound{message: "No rekey in progress"}
+	}
+
+	return &Rekey{
+		client: v,
+		state:  state,
+	}, nil
+}
+
+//This is here because in Vault 0.10.3, a regression was introduced that causes
+// rekey operations against an uninitialized or sealed Vault to return a 500
+// instead of a 503
+func (v *Client) correct500Error(err error) error {
+	//Thanks, Vault 0.10.3
+	if _, is500 := err.(*ErrInternalServer); is500 {
+		tmpErr := v.Health(true)
+		if _, isUninitialized := tmpErr.(*ErrUninitialized); isUninitialized {
+			err = tmpErr
+		} else if _, isSealed := tmpErr.(*ErrSealed); isSealed {
+			err = tmpErr
+		}
+	}
+
+	return err
+}
+
+func (v *Client) rekeyStart(conf RekeyConfig) error {
+	return v.doSysRequest("PUT", "/sys/rekey/init", &conf, nil)
+}
+
+//Cancel tells Vault to forget about the current rekey operation
+func (r *Rekey) Cancel() error {
+	return r.client.RekeyCancel()
+}
+
+//RekeyCancel tells Vault to forget about the current rekey operation
+func (v *Client) RekeyCancel() error {
+	return v.doSysRequest("DELETE", "/sys/rekey/init", nil, nil)
+}
+
+//Before 0.10, it was "no rekey in progress". In 0.10, the word barrier was added
+var rekeyRegexp = regexp.MustCompile("no (barrier )?rekey in progress")
+
+//Submit gives keys to the rekey operation specified by this *Rekey object. Any
+//keys beyond the current required amount are ignored. If the Rekey is
+//successful after all keys have been sent, then done will be returned as true.
+//If the threshold is reached and any of the keys were incorrect, an
+//*ErrBadRequest is returned and done is false. In this case, the rekey is not
+//cancelled, but is instead reset. No error is given for an incorrect key
+//before the threshold is reached. An *ErrBadRequest may also be returned if
+//there is no longer any rekey in progress, but in this case, done will be
+//returned as true. To retrieve the new keys after submitting enough existing
+//keys, call Keys() on the Rekey object.
+func (r *Rekey) Submit(keys ...string) (done bool, err error) {
+	for _, key := range keys {
+		var result interface{}
+		result, err = r.client.rekeySubmit(key, r.state.Nonce)
+		if err != nil {
+			if ebr, is400 := err.(*ErrBadRequest); is400 {
+				r.state.Progress = 0
+				//I really hate error string checking, but there's no good way that doesn't
+				//require another API call (which could, in turn, err, and leave us in a
+				//wrong state). This checks if the rekey operation is no longer in
+				//progress
+				if rekeyRegexp.MatchString(ebr.message) {
+					done = true
+				}
+			}
+
+			return
+		}
+
+		switch v := result.(type) {
+		case *RekeyState:
+			r.state = *v
+		case *rekeyKeys:
+			r.keys = v.Keys
+			r.state = RekeyState{}
+			return true, nil
+
+		default:
+			panic("rekeySubmit gave an unknown type")
+		}
+	}
+
+	return false, nil
+}
+
+type rekeyKeys struct {
+	Keys       []string `json:"keys"`
+	KeysBase64 []string `json:"keys_base64"`
+}
+
+func (v *Client) rekeySubmit(key string, nonce string) (ret interface{}, err error) {
+	if key == "" {
+		err = fmt.Errorf("no key provided")
+		return
+	}
+	if nonce == "" {
+		err = fmt.Errorf("no nonce provided")
+		return
+	}
+
+	tempMap := make(map[string]interface{})
+	err = v.doSysRequest(
+		"PUT",
+		"/sys/rekey/update",
+		&struct {
+			Key   string `json:"key"`
+			Nonce string `json:"nonce"`
+		}{
+			Key:   key,
+			Nonce: nonce,
+		},
+		&tempMap,
+	)
+	if err != nil {
+		return
+	}
+
+	jBytes, err := json.Marshal(&tempMap)
+	if err != nil {
+		return
+	}
+
+	var unmarshalTarget interface{} = &RekeyState{}
+	if _, isComplete := tempMap["complete"]; isComplete {
+		unmarshalTarget = &rekeyKeys{}
+	}
+
+	err = json.Unmarshal(jBytes, &unmarshalTarget)
+	if err != nil {
+		return
+	}
+
+	return unmarshalTarget, err
+}
+
+//Remaining returns the number of keys yet required by this rekey operation.
+//This does not refresh state. If you believe that an external agent may have
+//changed the state of the rekey, get a new rekey object with CurrentRekey, or
+//Submit another key.
+func (r *Rekey) Remaining() int {
+	return r.state.Required - r.state.Progress
+}
+
+//State returns the current state of the rekey operation. This does not refresh
+// state. If you believe that an external agent may have changed the state of
+// the rekey, get a new rekey object with CurrentRekey, or Submit another key.
+func (r *Rekey) State() RekeyState {
+	return r.state
+}
+
+//Keys returns the new keys from this rekey operation if the operation has been
+//successful. The return value is undefined if the rekey operation is not yet
+//successful.
+func (r *Rekey) Keys() []string {
+	return r.keys
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/root.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/root.go
@@ -1,0 +1,165 @@
+package vaultkv
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+)
+
+//GenerateRoot has functions for generating a new root token. Create this
+//object with NewGenerateRoot(). That function performs the necessary
+//initialization for the process
+type GenerateRoot struct {
+	client *Client
+	otp    []byte
+	state  GenerateRootState
+}
+
+//GenerateRootState contains state information about the GenerateRoot operation
+type GenerateRootState struct {
+	Started  bool   `json:"started"`
+	Nonce    string `json:"nonce"`
+	Progress int    `json:"progress"`
+	Required int    `json:"required"`
+	//Vault versions >= 0.9.x return the value as encoded_token
+	EncodedToken string `json:"encoded_token"`
+	//Vault versions before 0.9.x returned the value as encoded_root_token
+	EncodedRootToken string `json:"encoded_root_token"`
+	Complete         bool   `json:"complete"`
+}
+
+//NewGenerateRoot initializes and returns a new generate root object.
+func (v *Client) NewGenerateRoot() (*GenerateRoot, error) {
+	ret := GenerateRoot{
+		client: v,
+		otp:    make([]byte, 16),
+	}
+	_, err := rand.Read(ret.otp)
+	if err != nil {
+		return nil, fmt.Errorf("Could not generate random values")
+	}
+
+	base64OTP := make([]byte, base64.StdEncoding.EncodedLen(len(ret.otp)))
+	base64.StdEncoding.Encode(base64OTP, ret.otp)
+
+	err = v.doRequest("PUT", "/sys/generate-root/attempt",
+		map[string]string{"otp": string(base64OTP)}, &ret.state)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &ret, nil
+}
+
+var genRootRegexp = regexp.MustCompile("no root generation in progress")
+
+//Submit gives keys to the generate root token operation specified by this
+//*GenerateRoot object. Any keys beyond the current required amount are
+//ignored. If the Rekey is successful after all keys have been sent, then done
+//will be returned as true. If the threshold is reached and any of the keys
+//were incorrect, an *ErrBadRequest is returned and done is false. In this
+//case, the generate root is not cancelled, but is instead reset. No error is
+//given for an incorrect key before the threshold is reached. An *ErrBadRequest
+//may also be returned if there is no longer any generate root token operation
+//in progress, but in this case, done will be returned as true. To retrieve the
+//new keys after submitting enough existing keys, call RootToken() on the
+//GenerateRoot object.
+func (g *GenerateRoot) Submit(keys ...string) (done bool, err error) {
+	for _, key := range keys {
+		g.state, err = g.client.genRootSubmit(key, g.state.Nonce)
+		if err != nil {
+			if ebr, is400 := err.(*ErrBadRequest); is400 {
+				g.state.Progress = 0
+				//I really hate error string checking, but there's no good way that doesn't
+				//require another API call (which could, in turn, err, and leave us in a
+				//wrong state). This checks if the generate root token is no longer in
+				// progress
+				if genRootRegexp.MatchString(ebr.message) {
+					done = true
+				}
+			}
+
+			return
+		}
+
+		if g.state.Complete {
+			break
+		}
+	}
+
+	return g.state.Complete, nil
+}
+
+//Cancel cancels the current generate root operation
+func (g *GenerateRoot) Cancel() error {
+	return g.client.GenerateRootCancel()
+}
+
+//GenerateRootCancel cancels the current generate root operation
+func (v *Client) GenerateRootCancel() error {
+	return v.doSysRequest("DELETE", "/sys/generate-root/attempt", nil, nil)
+}
+
+func (v *Client) genRootSubmit(key string, nonce string) (ret GenerateRootState, err error) {
+	err = v.doSysRequest(
+		"PUT",
+		"/sys/generate-root/update",
+		&struct {
+			Key   string `json:"key"`
+			Nonce string `json:"nonce"`
+		}{
+			Key:   key,
+			Nonce: nonce,
+		},
+		&ret,
+	)
+
+	return
+}
+
+//Remaining returns the number of keys yet required by this generate root token
+//operation. This does not refresh state, and only reflects the last action of
+//this GenerateRoot object.
+func (g *GenerateRoot) Remaining() int {
+	return g.state.Required - g.state.Progress
+}
+
+//State returns the current state of the generate root operation. This does not
+//refresh state, and only reflects the last action of this GenerateRoot object.
+func (g *GenerateRoot) State() GenerateRootState {
+	return g.state
+}
+
+//RootToken returns the new root token from this operation if the operation has
+//been successful. The return value is undefined if the operation is not yet
+//successful.
+func (g *GenerateRoot) RootToken() (string, error) {
+	rawTok := g.state.EncodedToken
+	if rawTok == "" {
+		rawTok = g.state.EncodedRootToken
+	}
+
+	tokBase64 := []byte(rawTok)
+	tok := make([]byte, base64.StdEncoding.DecodedLen(len(tokBase64)))
+
+	tokenLen, err := base64.StdEncoding.Decode(tok, tokBase64)
+	if err != nil {
+		return "", fmt.Errorf("Could not decode base64 token: %s", err)
+	}
+	if tokenLen != len(g.otp) {
+		return "", fmt.Errorf("token length / one-time password length mismatch (%d/%d)", tokenLen, len(g.otp))
+	}
+	tok = tok[:tokenLen]
+	for i := 0; i < len(g.otp); i++ {
+		tok[i] ^= g.otp[i]
+	}
+
+	tokHex := make([]byte, hex.EncodedLen(tokenLen))
+	hex.Encode(tokHex, tok)
+	return fmt.Sprintf("%s-%s-%s-%s-%s",
+			tokHex[0:8], tokHex[8:12], tokHex[12:16], tokHex[16:20], tokHex[20:]),
+		nil
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/sys.go
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/sys.go
@@ -1,0 +1,234 @@
+package vaultkv
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func (v *Client) doSysRequest(
+	method, path string,
+	input interface{},
+	output interface{}) error {
+	err := v.doRequest(method, path, input, output)
+	//In sys contexts, 400 can mean that the Vault is uninitialized.
+	if _, is400 := err.(*ErrBadRequest); is400 {
+		initialized, initErr := v.IsInitialized()
+		if initErr != nil {
+			return initErr
+		}
+
+		if !initialized {
+			return &ErrUninitialized{message: "Your Vault is not initialized"}
+		}
+	}
+
+	return err
+}
+
+//IsInitialized returns true if the targeted Vault is initialized
+func (v *Client) IsInitialized() (is bool, err error) {
+	//Don't call doSysRequest from here because it calls IsInitialized
+	// and that could get ugly
+	err = v.doRequest(
+		"GET",
+		"/sys/init",
+		nil,
+		&struct {
+			Initialized *bool `json:"initialized"`
+		}{
+			Initialized: &is,
+		})
+
+	return
+}
+
+//SealState is the return value from Unseal and SealStatus. Type is only
+//populated by SealStatus. ClusterName and ClusterID are only populated is
+//Vault is unsealed.
+type SealState struct {
+	//Type is the type of unseal key. It is not returned from Unseal
+	Type   string `json:"type,omitempty"`
+	Sealed bool   `json:"sealed"`
+	//Threshold is the number of keys required to reconstruct the master key
+	Threshold int `json:"t"`
+	//NumShares is the number of keys the master key has been split into
+	NumShares int `json:"n"`
+	//Progress is the number of keys that have been provided in the current unseal attempt
+	Progress int    `json:"progress"`
+	Nonce    string `json:"nonce"`
+	Version  string `json:"version"`
+	//ClusterName is only returned from an unsealed Vault.
+	ClusterName string `json:"cluster_name,omitempty"`
+	//ClusterID is only returned from an unsealed Vault.
+	ClusterID string `json:"cluster_id,omitempty"`
+}
+
+//SealStatus calls the /sys/seal-status endpoint and returns the info therein
+func (v *Client) SealStatus() (ret *SealState, err error) {
+	err = v.doSysRequest(
+		"GET",
+		"/sys/seal-status",
+		nil,
+		&ret)
+
+	return
+}
+
+//InitConfig is the information passed to InitVault to configure the Vault.
+//Shares and Threshold are required.
+type InitConfig struct {
+	//Split the master key into this many shares
+	Shares int `json:"secret_shares"`
+	//This many shares are required to reconstruct the master key
+	Threshold       int      `json:"secret_threshold"`
+	RootTokenPGPKey string   `json:"root_token_pgp_key"`
+	PGPKeys         []string `json:"pgp_keys"`
+}
+
+//InitVaultOutput is the return value of InitVault, and contains the generated
+//Keys and RootToken.
+type InitVaultOutput struct {
+	client     *Client
+	Keys       []string `json:"keys"`
+	KeysBase64 []string `json:"keys_base64"`
+	RootToken  string   `json:"root_token"`
+}
+
+//Unseal takes the keys in the InitVaultOutput object and sends each one to the
+//unseal endpoint. If any of the unseal calls are unsuccessful, an error is
+//returned.
+func (i *InitVaultOutput) Unseal() error {
+	for _, key := range i.Keys {
+		sealState, err := i.client.Unseal(key)
+		if err != nil {
+			return err
+		}
+
+		if !sealState.Sealed {
+			break
+		}
+	}
+
+	return nil
+}
+
+//InitVault puts to the /sys/init endpoint to initialize the Vault, and returns
+// the root token and unseal keys that were generated. The token of the client
+// object is automatically set to the root token if the init is successful.
+//If the vault has already been initialized, this returns *ErrBadRequest
+func (v *Client) InitVault(in InitConfig) (out *InitVaultOutput, err error) {
+	out = &InitVaultOutput{}
+	err = v.doSysRequest(
+		"PUT",
+		"/sys/init",
+		&in,
+		&out,
+	)
+
+	if err == nil {
+		v.AuthToken = out.RootToken
+	}
+
+	out.client = v
+
+	return
+}
+
+//Seal puts to the /sys/seal endpoint to seal the Vault.
+// If the Vault is already sealed, this doesn't return an error.
+// If the Vault is unsealed and an incorrect token is provided, then this
+// returns *ErrForbidden.
+func (v *Client) Seal() error {
+	return v.doSysRequest("PUT", "/sys/seal", nil, nil)
+}
+
+//Unseal puts to the /sys/unseal endpoint with a single key to progress the
+//unseal attempt. If the unseal was successful, then the Sealed member of the
+//returned struct will be false. If the given unseal key is improperly
+//formatted, an *ErrBadRequest is returned. If the vault is already unsealed,
+//no error is returned
+func (v *Client) Unseal(key string) (out *SealState, err error) {
+	out = &SealState{}
+	err = v.doSysRequest(
+		"PUT",
+		"/sys/unseal",
+		&struct {
+			Key string `json:"key"`
+		}{
+			Key: key,
+		},
+		&out,
+	)
+
+	return
+}
+
+//ResetUnseal resets the current unseal attempt, such that the progress towards
+//an unseal becomes 0. If the vault is unsealed, nothing happens and no error
+//is returned.
+func (v *Client) ResetUnseal() (err error) {
+	err = v.doSysRequest(
+		"PUT",
+		"/sys/unseal",
+		&struct {
+			Reset bool `json:"reset"`
+		}{
+			Reset: true,
+		},
+		nil,
+	)
+
+	return
+}
+
+//Health gives information about the current state of the Vault. If standbyok
+//is set to true, no error will be returned in the case that the targeted vault
+//is a standby node. If the targeted node is a standby and standbyok is false,
+//then ErrStandby will be returned. If the Vault is not yet initialized,
+//ErrUninitialized will be returned. If the Vault is initialized but sealed,
+//then ErrSealed will be returned. If none of these are the case, no error is
+//returned.
+func (v *Client) Health(standbyok bool) error {
+	//Don't call doRequest from Health because ParseError calls Health
+	query := url.Values{}
+	boolStr := "false"
+	if standbyok == true {
+		boolStr = "true"
+	}
+	query.Add("standbyok", boolStr)
+	u := *v.VaultURL
+	u.Path = "/v1/sys/health"
+	u.RawQuery = query.Encode()
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("X-Vault-Token", v.AuthToken)
+	resp, err := v.Client.Do(req)
+	if err != nil {
+		return &ErrTransport{message: err.Error()}
+	}
+
+	errorsStruct := apiError{}
+	json.NewDecoder(resp.Body).Decode(&errorsStruct)
+	errorMessage := strings.Join(errorsStruct.Errors, "\n")
+
+	switch resp.StatusCode {
+	case 200:
+		err = nil
+	case 429:
+		err = &ErrStandby{message: errorMessage}
+	case 501:
+		err = &ErrUninitialized{message: errorMessage}
+	case 503:
+		err = &ErrSealed{message: errorMessage}
+	default:
+		err = errors.New(errorMessage)
+	}
+
+	return err
+}

--- a/vendor/github.com/cloudfoundry-community/vaultkv/test
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/test
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+vaultVersions=("0.6.5" "0.7.3" "0.8.3" "0.9.6" "0.10.4" "0.11.0")
+
+if [[ -z $1 ]]; then
+	for version in "${vaultVersions[@]}"; do
+    ginkgo -noisySkippings=false -p -- -v="$version"
+  done
+elif [[ $1 == "latest" ]]; then
+  ginkgo -noisySkippings=false -p -- -v="${vaultVersions[${#vaultVersions}-1]}"
+else
+  echo "Unknown arg"
+  exit 1
+fi

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "i5IG3zDlrJYYPJB5NqOnlPWMt8M=",
+			"path": "github.com/cloudfoundry-community/vaultkv",
+			"revision": "b4b55025a795495017442261055ceafc80a99de2",
+			"revisionTime": "2018-09-20T22:51:27Z"
+		},
+		{
 			"checksumSHA1": "17vYJDDMJO63/G/tRFIUuSlMCbE=",
 			"path": "github.com/ghodss/yaml",
 			"revision": "73d445a93680fa1a78ae23a5839bad48f32ba1ee"


### PR DESCRIPTION
Hashicorp is not shy about making Vault releases, and not all of those
releases are entirely backwards compatible. VaultKV, I'm hoping, is a
library where the effort of smoothing out the differences between Vault
versions can benefit multiple projects. Therefore, as we move forward
into probably needing to support k/v v2 backends, that is the place
where the effort has been made, and safe can simply use it. This patch
is mostly a no-op from a behavior standpoint, except that

1. Some errors messages have changed, because they were tied to what the
API library returned.
2. Rekey automatically cancels a preexisting rekey. This is probably the behavior that people want 99% of the time. If somebody needs this not to happen, we can make a flag for the behavior.

The rekey behavior thing is actually avoidable. I think my reason for changing it was to make it consistent with the way generate root works, but if we want to leave that alone, I can revert that particular change.