### PR TITLE
--signed-by flag on x509 validate works

### DIFF
--- a/main.go
+++ b/main.go
@@ -2351,6 +2351,14 @@ The following options are recognized:
 				}
 			}
 
+			if ca != nil { //If --signed-by was specified...
+				err = cert.Certificate.CheckSignatureFrom(ca.Certificate)
+
+				if err != nil {
+					return fmt.Errorf("%s was not signed by %s", path, opt.X509.Validate.SignedBy)
+				}
+			}
+
 			fmt.Printf("@G{%s} checks out.\n", path)
 		}
 


### PR DESCRIPTION
it now checks if the cert was signed by the cert specified in the value
to --signed-by. Of note is that this check will fail if the cert
specified in --signed-by does not have the CA x509 constraint.

Closes #165 