### PR TITLE
Multithread tree

### DIFF
--- a/tests
+++ b/tests
@@ -1864,7 +1864,7 @@ EOF
   now checking the output
   cat >t/home/want <<EOF ; diffok
 .
-└── secret/tree
+└── secret/tree/
     ├── alpha
     ├── beta/
     │   ├── env
@@ -1887,7 +1887,7 @@ EOF
   now checking the output
   cat >t/home/want <<EOF ; diffok
 .
-└── secret/tree
+└── secret/tree/
     ├── beta/
     └── g/
         └── a/
@@ -1921,7 +1921,7 @@ EOF
   now checking that tree output contains :keys
   cat <<'EOF' >t/home/want ; diffok
 .
-├── secret/tree/a
+├── secret/tree/a/
 │   └── b/
 │       ├── c
 │       │   └── :subkey

--- a/vault/tree.go
+++ b/vault/tree.go
@@ -1,0 +1,434 @@
+package vault
+
+import (
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/jhunt/go-ansi"
+	"github.com/starkandwayne/goutils/tree"
+)
+
+//This is a synchronized queue that specifically works with our tree algorithm,
+// in which the workers that pull work off the queue are also responsible for
+// populating the queue. This is because of the recursive nature of the tree
+// population. All workers are released when all workers are simultaneously
+// waiting on an empty queue.
+type workQueue struct {
+	head   *workQueueNode
+	tail   *workQueueNode
+	c      *sync.Cond
+	awake  int
+	closed bool
+}
+
+type workQueueNode struct {
+	next    *workQueueNode
+	payload *workOrder
+}
+
+func newWorkQueue(numWorkers int) *workQueue {
+	return &workQueue{
+		c:     sync.NewCond(&sync.Mutex{}),
+		awake: numWorkers,
+	}
+}
+
+func (w *workQueue) Pop() (ret *workOrder, done bool) {
+	w.c.L.Lock()
+	//While it'd be more "correct" logically to put this inside the loop, its a
+	// minor optimization to keep it outside - it all looks the same transactionally
+	// anyway
+	w.awake--
+	for w.head == nil && !w.closed {
+		//This would mean that all the workers would be waiting for something new
+		// to enter the queue. Given that the workers are also responsible for
+		// populating the queue, this means that nothing else can possibly enter
+		// and that we're done
+		if w.awake == 0 {
+			w.closed = true
+			w.c.Broadcast()
+			break
+		}
+
+		w.c.Wait()
+	}
+	if w.closed {
+		w.c.L.Unlock()
+		return nil, true
+	}
+
+	w.awake++
+
+	ret = w.head.payload
+	w.head = w.head.next
+	if w.head == nil {
+		w.tail = nil
+	}
+
+	w.c.L.Unlock()
+	return ret, false
+}
+
+func (w *workQueue) Push(o *workOrder) {
+	w.c.L.Lock()
+	if w.closed {
+		return
+	}
+
+	toAdd := &workQueueNode{payload: o}
+
+	if w.tail != nil {
+		w.tail.next = toAdd
+	} else { //tail is nil iff head is nil
+		w.head = toAdd
+	}
+
+	w.tail = toAdd
+
+	w.c.L.Unlock()
+	w.c.Signal()
+}
+
+func (w *workQueue) Close() {
+	w.c.L.Lock()
+	if !w.closed {
+		w.closed = true
+		w.c.Broadcast()
+	}
+	w.c.L.Unlock()
+}
+
+type workOrder struct {
+	insertInto *[]Tree
+	path       string
+	operation  int
+}
+
+type Tree struct {
+	Name     string
+	Branches []Tree
+	Type     int
+	Value    string
+}
+
+const (
+	TreeTypeRoot int = iota
+	TreeTypeDir
+	TreeTypeSecret
+	TreeTypeDirAndSecret
+	TreeTypeKey
+)
+
+const (
+	opTypeNone int = iota
+	opTypeList
+	opTypeGet
+	opTypeListAndGet
+	opTypeMounts
+)
+
+func (v *Vault) ConstructTree(path string, fetchKeys bool) (*Tree, error) {
+	//3 is what I found to be the fastest in testing. Seems dumb but... works, I guess.
+	numWorkers := runtime.NumCPU()
+	if numWorkers < 1 {
+		numWorkers = 1
+	}
+	if numWorkers > 3 {
+		numWorkers = 3
+	}
+
+	queue := newWorkQueue(numWorkers)
+	errChan := make(chan error)
+
+	path = Canonicalize(path)
+	if path == "" {
+		path = "/"
+	}
+	ret := &Tree{Name: path}
+	err := ret.populateNodeType(v)
+	if err != nil {
+		return nil, err
+	}
+
+	queue.Push(&workOrder{
+		insertInto: &ret.Branches,
+		path:       ret.Name,
+		operation:  ret.getWorkType(fetchKeys),
+	})
+
+	for i := 0; i < numWorkers; i++ {
+		worker := treeWorker{
+			vault:     v,
+			orders:    queue,
+			errors:    errChan,
+			fetchKeys: fetchKeys,
+		}
+		go worker.work()
+	}
+
+	//Workers return on errChan when they finish. They'll throw back nil if no
+	// errors were encountered
+	for i := 0; i < numWorkers; i++ {
+		thisErr := <-errChan
+		if thisErr != nil {
+			err = thisErr
+		}
+	}
+
+	return ret, err
+}
+
+//Only use this for the base for the initial node of the tree. You can infer
+// type much faster than this if you know the operation that retrieved it in the
+// first place.
+func (t *Tree) populateNodeType(v *Vault) error {
+	if t.Name == "/" {
+		t.Type = TreeTypeRoot
+		return nil
+	}
+
+	_, err := v.Read(t.Name)
+	if err != nil {
+		if !IsNotFound(err) {
+			return err
+		}
+
+		t.Type = TreeTypeDir
+	} else {
+		t.Type = TreeTypeSecret
+
+		_, err := v.List(t.Name)
+		if err == nil {
+			t.Type = TreeTypeDirAndSecret
+		}
+		if err != nil && !IsNotFound(err) {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *Tree) getWorkType(fetchKeys bool) int {
+	var ret int
+	switch t.Type {
+	case TreeTypeRoot:
+		ret = opTypeMounts
+	case TreeTypeDir:
+		t.Name = strings.TrimRight(t.Name, "/") + "/"
+		ret = opTypeList
+	case TreeTypeDirAndSecret:
+		ret = opTypeList
+		if fetchKeys {
+			ret = opTypeListAndGet
+		}
+	case TreeTypeSecret:
+		ret = opTypeNone
+		if fetchKeys {
+			ret = opTypeGet
+		}
+	}
+
+	return ret
+}
+
+func (t Tree) Paths() []string {
+	ret := make([]string, 0, 0)
+
+	if len(t.Branches) == 0 {
+		ret = append(ret, t.Name)
+	} else {
+		for _, branch := range t.Branches {
+			ret = append(ret, branch.Paths()...)
+		}
+	}
+
+	return ret
+}
+
+func (t Tree) Basename() string {
+	var ret string
+	switch t.Type {
+	case TreeTypeRoot:
+		ret = "/"
+	case TreeTypeDir:
+		splits := strings.Split(strings.TrimRight(t.Name, "/"), "/")
+		ret = splits[len(splits)-1] + "/"
+	case TreeTypeSecret, TreeTypeDirAndSecret:
+		splits := strings.Split(strings.TrimRight(t.Name, "/"), "/")
+		ret = splits[len(splits)-1]
+	case TreeTypeKey:
+		splits := strings.Split(t.Name, ":")
+		ret = splits[len(splits)-1]
+	}
+
+	return ret
+}
+
+func (t *Tree) DepthFirstMap(fn func(*Tree)) {
+	for i := range t.Branches {
+		fn(&t.Branches[i])
+		t.Branches[i].DepthFirstMap(fn)
+	}
+}
+
+func (t Tree) Draw(color bool, leaves bool) string {
+	printTree := t.printableTree(color, leaves, true)
+	return printTree.Draw()
+}
+
+func (t Tree) printableTree(color, leaves, root bool) *tree.Node {
+	if t.Type == TreeTypeSecret && !leaves {
+		return nil
+	}
+
+	name := t.Name
+	if !root {
+		name = t.Basename()
+		if t.Type == TreeTypeKey {
+			name = ":" + name
+		}
+	}
+
+	const dirFmt, secFmt, keyFmt = "@B{%s}", "@G{%s}", "@Y{%s}"
+	if color {
+		switch t.Type {
+		case TreeTypeDir, TreeTypeRoot:
+			name = ansi.Sprintf(dirFmt, name)
+		case TreeTypeSecret, TreeTypeDirAndSecret:
+			name = ansi.Sprintf(secFmt, name)
+		case TreeTypeKey:
+			name = ansi.Sprintf(keyFmt, name)
+		}
+	}
+
+	ret := &tree.Node{
+		Name: name,
+	}
+
+	for i := range t.Branches {
+		toAdd := t.Branches[i].printableTree(color, leaves, false)
+		if toAdd != nil {
+			ret.Append(*toAdd)
+		}
+	}
+
+	return ret
+}
+
+type treeWorker struct {
+	vault     *Vault
+	orders    *workQueue
+	errors    chan error
+	fetchKeys bool
+}
+
+func (w *treeWorker) work() {
+	order, done := w.orders.Pop()
+	for !done {
+		var answer []Tree
+		var err error
+		switch order.operation {
+		case opTypeList:
+			answer, err = w.workList(order.path)
+		case opTypeGet:
+			answer, err = w.workGet(order.path)
+		case opTypeListAndGet:
+			answer, err = w.workGet(order.path)
+			if err != nil {
+				break
+			}
+
+			var listAnswer []Tree
+			listAnswer, err = w.workList(order.path + "/")
+			answer = append(answer, listAnswer...)
+		case opTypeMounts:
+			answer, err = w.workMounts()
+		}
+
+		if err != nil {
+			w.orders.Close()
+			w.errors <- err
+			//This will decrement the awake counter and exit
+			w.orders.Pop()
+			return
+		}
+
+		*order.insertInto = append(*order.insertInto, answer...)
+		for i, node := range *order.insertInto {
+			w.orders.Push(&workOrder{
+				insertInto: &(*order.insertInto)[i].Branches,
+				path:       node.Name,
+				operation:  node.getWorkType(w.fetchKeys),
+			})
+		}
+
+		order, done = w.orders.Pop()
+	}
+
+	w.errors <- nil
+}
+
+func (w *treeWorker) workList(path string) ([]Tree, error) {
+	list, err := w.vault.List(path)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []Tree{}
+	for _, l := range list {
+		t := TreeTypeSecret
+		if strings.HasSuffix(l, "/") {
+			t = TreeTypeDir
+		}
+		ret = append(ret, Tree{
+			Name: strings.TrimRight(path, "/") + "/" + l,
+			Type: t,
+		})
+	}
+
+	return ret, nil
+}
+
+func (w *treeWorker) workGet(path string) ([]Tree, error) {
+	s, err := w.vault.Read(path)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []Tree{}
+	for _, key := range s.Keys() {
+		ret = append(ret, Tree{
+			Name:  path + ":" + key,
+			Type:  TreeTypeKey,
+			Value: s.data[key],
+		})
+	}
+
+	return ret, nil
+}
+
+func (w *treeWorker) workMounts() ([]Tree, error) {
+	generics, err := w.vault.Mounts("generic")
+	if err != nil {
+		return nil, err
+	}
+
+	kvs, err := w.vault.Mounts("kv")
+	if err != nil {
+		return nil, err
+	}
+
+	mounts := append(kvs, generics...)
+
+	ret := []Tree{}
+	for _, mount := range mounts {
+		ret = append(ret, Tree{
+			Name: mount + "/",
+			Type: TreeTypeDir,
+		})
+	}
+
+	return ret, nil
+}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cloudfoundry-community/vaultkv"
 	"github.com/jhunt/go-ansi"
-	"github.com/starkandwayne/goutils/tree"
 )
 
 type Vault struct {
@@ -153,121 +152,6 @@ func (v *Vault) List(path string) (paths []string, err error) {
 	return paths, err
 }
 
-type TreeOptions struct {
-	UseANSI      bool /* Use ANSI colorizing sequences */
-	HideLeaves   bool /* Hide leaf nodes of the tree (actual secrets) */
-	ShowKeys     bool /* Include keys in the output */
-	InSubbranch  bool /* If true, suppresses key output on branches */
-	StripSlashes bool /* If true, strip the trailing slashes from interior nodes */
-}
-
-func (v *Vault) walktree(path string, options TreeOptions) (tree.Node, int, error) {
-	var key_fmt string
-	if options.UseANSI {
-		key_fmt = "@Y{:%s}"
-	} else {
-		key_fmt = ":%s"
-	}
-
-	t := tree.New(path)
-	l, err := v.List(path)
-	if err != nil {
-		//This can be either because a leaf is being listed or because nothing is
-		// there at all
-		if IsNotFound(err) {
-			//If we need the subkeys inside a leaf...
-			if options.ShowKeys {
-				//Then we actually need to check if its a leaf
-				if s, err := v.Read(path); err == nil {
-					for _, key := range s.Keys() {
-						t.Append(tree.New(ansi.Sprintf(key_fmt, key)))
-					}
-				}
-			}
-
-			err = nil
-		}
-		return t, 0, err
-	}
-
-	if options.ShowKeys && !options.InSubbranch {
-		if s, err := v.Read(path); err == nil {
-			for _, key := range s.Keys() {
-				key_name := ansi.Sprintf(key_fmt, key)
-				t.Append(tree.New(key_name))
-			}
-		}
-	}
-	options.InSubbranch = true
-	for _, p := range l {
-		if strings.HasSuffix(p, "/") {
-			kid, n, err := v.walktree(path+"/"+p[0:len(p)-1], options)
-			if err != nil {
-				return t, 0, err
-			}
-			if n == 0 {
-				fmt.Fprintf(os.Stderr, "%s\n", kid.Name)
-				continue
-			}
-			if options.StripSlashes {
-				p = p[0 : len(p)-1]
-			}
-			if options.UseANSI {
-				kid.Name = ansi.Sprintf("@B{%s}", p)
-			} else {
-				kid.Name = p
-			}
-			t.Append(kid)
-
-		} else if options.HideLeaves {
-			continue
-
-		} else {
-			var name string
-			if options.UseANSI {
-				name = ansi.Sprintf("@G{%s}", p)
-			} else {
-				name = p
-			}
-			leaf := tree.New(name)
-			if options.ShowKeys {
-				if s, err := v.Read(path + "/" + p); err == nil {
-					for _, key := range s.Keys() {
-						key_name := ansi.Sprintf(key_fmt, key)
-						leaf.Append(tree.New(key_name))
-					}
-				} else {
-					fmt.Fprintf(os.Stderr, "error: %s\n", err)
-				}
-
-			}
-			t.Append(leaf)
-		}
-	}
-	return t, len(l), nil
-}
-
-type treeTaskStack struct {
-	stack []workOrder
-}
-
-// Tree returns a tree that represents the hierarchy of paths contained
-// below the given path, inside of the Vault.
-func (v *Vault) Tree(path string, options TreeOptions) (tree.Node, error) {
-	path = Canonicalize(path)
-
-	t, _, err := v.walktree(path, options)
-	if err != nil {
-		return t, err
-	}
-	if options.UseANSI {
-		t.Name = ansi.Sprintf("@C{%s}", path)
-	} else {
-		t.Name = path
-	}
-	return t, nil
-}
-
 // Write takes a Secret and writes it to the Vault at the specified path.
 func (v *Vault) Write(path string, s *Secret) error {
 	path = Canonicalize(path)
@@ -319,13 +203,11 @@ func (v *Vault) verifySecretExists(path string) error {
 func (v *Vault) DeleteTree(root string) error {
 	root = Canonicalize(root)
 
-	tree, err := v.Tree(root, TreeOptions{
-		StripSlashes: true,
-	})
+	tree, err := v.ConstructTree(root, false)
 	if err != nil {
 		return err
 	}
-	for _, path := range tree.Paths("/") {
+	for _, path := range tree.Paths() {
 		err = v.deleteEntireSecret(path)
 		if err != nil {
 			return err
@@ -469,21 +351,21 @@ func (v *Vault) MoveCopyTree(oldRoot, newRoot string, f func(string, string, boo
 	oldRoot = Canonicalize(oldRoot)
 	newRoot = Canonicalize(newRoot)
 
-	tree, err := v.Tree(oldRoot, TreeOptions{})
+	tree, err := v.ConstructTree(oldRoot, false)
 	if err != nil {
 		return err
 	}
 	if skipIfExists {
-		newTree, err := v.Tree(newRoot, TreeOptions{})
+		newTree, err := v.ConstructTree(newRoot, false)
 		if err != nil && !IsNotFound(err) {
 			return err
 		}
 		existing := map[string]bool{}
-		for _, path := range newTree.Paths("/") {
+		for _, path := range newTree.Paths() {
 			existing[path] = true
 		}
 		existingPaths := []string{}
-		for _, path := range tree.Paths("/") {
+		for _, path := range tree.Paths() {
 			newPath := strings.Replace(path, oldRoot, newRoot, 1)
 			if existing[newPath] {
 				existingPaths = append(existingPaths, newPath)
@@ -499,7 +381,7 @@ func (v *Vault) MoveCopyTree(oldRoot, newRoot string, f func(string, string, boo
 			return nil
 		}
 	}
-	for _, path := range tree.Paths("/") {
+	for _, path := range tree.Paths() {
 		newPath := strings.Replace(path, oldRoot, newRoot, 1)
 		err = f(path, newPath, skipIfExists, quiet)
 		if err != nil {

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -247,6 +247,10 @@ func (v *Vault) walktree(path string, options TreeOptions) (tree.Node, int, erro
 	return t, len(l), nil
 }
 
+type treeTaskStack struct {
+	stack []workOrder
+}
+
 // Tree returns a tree that represents the hierarchy of paths contained
 // below the given path, inside of the Vault.
 func (v *Vault) Tree(path string, options TreeOptions) (tree.Node, error) {


### PR DESCRIPTION
This rewrites the core code that drives tree, paths, and export, as
well as recursive copy, move, and delete.
Requests to the vault are handled concurrently by worker threads,
showing a significant speedup in requests that had previously taken a
long period of time (and typically a minor speedup in those that did
not). As an added bonus, this also fixes a long-existent oddity where
safe did not error when trying to tree or paths a non-existent
path. Also, now you can specify "/" as a path to tree, paths, or export
to get the entire vault kv tree - not just the secrets mount.
There is a minor formatting difference in tree, such that the requested
path will appear as a directory if it is only a path (not a secret).
This seems like an improvement, but it is a behavioral difference nonetheless.