### PR TITLE
Update README with note about homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ATTENTION HOMEBREW USERS
 
 If you run Homebrew on MacOS, be aware that the the Formula for
 safe in homebrew core is outdated, incorrect, and unmaintained.
-We maintain our own tap, which you ar eencouraged to use instead:
+We maintain our own tap, which you are encouraged to use instead:
 
 ```
 brew tap starkandwayne/cf

--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ So, why `safe`?  To solve the following problems:
 Primarily, these are things encountered in trying to build secure
 BOSH deployments using Vault and [Spruce][spruce].
 
+ATTENTION HOMEBREW USERS
+------------------------
+
+If you run Homebrew on MacOS, be aware that the the Formula for
+safe in homebrew core is outdated, incorrect, and unmaintained.
+We maintain our own tap, which you ar eencouraged to use instead:
+
+```
+brew tap starkandwayne/cf
+brew install starkandwayne/cf/safe
+```
+
+
 Authentication
 --------------
 


### PR DESCRIPTION
Given that the homebrew team is citing "open source" as a defense of a poor user experience with respect to Homebrew usage and `safe` (viz https://github.com/Homebrew/homebrew-core/pull/33268), we should let our users know about the correct method of installing safe via brew.