### PR TITLE
Bump vaultkv to support vault 0.11.4.

### DIFF
--- a/tests
+++ b/tests
@@ -15,19 +15,21 @@ case $OSTYPE in
 (darwin*)
   platform=darwin
   declare -a versions=(
-    0.6.5
-    0.7.3
-    0.8.3
-    0.9.0
+    "0.7.3"
+    "0.8.3"
+    "0.9.6"
+    "0.10.4"
+    "0.11.4"
   )
   ;;
 (linux*)
   platform=linux
   declare -a versions=(
-    0.6.5
-    0.7.3
-    0.8.3
-    0.9.0
+    "0.7.3"
+    "0.8.3"
+    "0.9.6"
+    "0.10.4"
+    "0.11.4"
   )
   ;;
 (*)
@@ -293,6 +295,10 @@ restart_vault_server() {
   (run; ./safe target unit-tests http://127.0.0.1:8199) ; exitok $? 0
   now authenticating with ${root_token} root token
   (run; echo "$root_token" | ./safe auth token)         ; exitok $? 0
+  local engine="kv"
+  if [[ $version =~ ^0\.[6-8].* ]]; then engine="generic"; fi
+  now making sure that the backend is a kv v1 engine
+  (run; ./safe vault secrets disable secret/; ./safe vault secrets enable -path="secret/" "$engine"); exitok $? 0
 }
 
 mkdir -p vaults t/tmp
@@ -1586,7 +1592,8 @@ EOF
 
 
   if [[ -z "${TEST_QUICK:-}" ]]; then
-  for op in ssh rsa dhparam; do
+  for op in ssh rsa; do
+  #for op in ssh rsa dhparam; do
     case $op in
     ssh)     what="an SSH key" ;;
     rsa)     what="an RSA key" ;;

--- a/vendor/github.com/cloudfoundry-community/vaultkv/test
+++ b/vendor/github.com/cloudfoundry-community/vaultkv/test
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-vaultVersions=("0.6.5" "0.7.3" "0.8.3" "0.9.6" "0.10.4" "0.11.0")
+vaultVersions=("0.7.3" "0.8.3" "0.9.6" "0.10.4" "0.11.4")
 
 if [[ -z $1 ]]; then
 	for version in "${vaultVersions[@]}"; do
     ginkgo -noisySkippings=false -p -- -v="$version"
   done
 elif [[ $1 == "latest" ]]; then
-  ginkgo -noisySkippings=false -p -- -v="${vaultVersions[${#vaultVersions}-1]}"
+  latest="${vaultVersions[${#vaultVersions} - 1]}"
+  echo "testing latest version: $latest"
+  ginkgo -noisySkippings=false -p -- -v="$latest"
 else
   echo "Unknown arg"
   exit 1

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "i5IG3zDlrJYYPJB5NqOnlPWMt8M=",
+			"checksumSHA1": "wRj07gw6tqbmfSvZ95mQZexZKWo=",
 			"path": "github.com/cloudfoundry-community/vaultkv",
-			"revision": "b4b55025a795495017442261055ceafc80a99de2",
-			"revisionTime": "2018-09-20T22:51:27Z"
+			"revision": "533805f03a1b7ea8fd93cb7272f554d4929ca79e",
+			"revisionTime": "2018-10-25T21:40:29Z"
 		},
 		{
 			"checksumSHA1": "17vYJDDMJO63/G/tRFIUuSlMCbE=",


### PR DESCRIPTION
This also updates our tests to test with newer versions of Vault.
Generate root changed in a recent Vault release. vaultkv fixed it, and
so we fix it here.

The branch is a stupid name, considering I actually bumped to 0.11.4 but... ugh.

Closes #171 
Demonstrates that #138 is really about KV v2 incompatibility. Should probably change the name of that issue.