### PR TITLE
Split Read / Apply in twain, to fix #160

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+# Improvements
+
+- `safe target` no longer cares if your current target is valid
+  before overwriting it.

--- a/main.go
+++ b/main.go
@@ -343,7 +343,12 @@ func main() {
 		Usage:   "safe [-k] target [URL] [ALIAS] | safe target -i",
 		Type:    AdministrativeCommand,
 	}, func(command string, args ...string) error {
-		cfg := rc.Apply(opt.UseTarget)
+		var cfg rc.Config
+		if !opt.Target.Interactive && len(args) == 0 {
+			cfg = rc.Apply(opt.UseTarget)
+		} else {
+			cfg = rc.Read()
+		}
 		skipverify := false
 		if os.Getenv("SAFE_SKIP_VERIFY") == "1" {
 			skipverify = true

--- a/rc/config.go
+++ b/rc/config.go
@@ -84,7 +84,7 @@ func (c *Config) credentials() (string, string, bool, error) {
 	return v.URL, v.Token, v.SkipVerify, nil
 }
 
-func Apply(use string) Config {
+func Read() Config {
 	var c Config
 
 	b, err := ioutil.ReadFile(saferc())
@@ -103,6 +103,12 @@ func Apply(use string) Config {
 		}
 		c = legacy.convert()
 	}
+
+	return c
+}
+
+func Apply(use string) Config {
+	c := Read()
 
 	if err := c.Apply(use); err != nil {
 		fmt.Fprintf(os.Stderr, "@R{!!! %s}\n", err)


### PR DESCRIPTION
`safe target` shouldn't care about the current target, in case someone
is editing their saferc manually and flubs.

Fixes #160 