### PR TITLE
Implement Global (Target-Independent) Options

### DIFF
--- a/rc/config.go
+++ b/rc/config.go
@@ -23,7 +23,7 @@ type Config struct {
 }
 
 type Options struct {
-	ManageVaultToken bool `yaml:"manage_vault_token,omitempty"`
+	ManageVaultToken bool `yaml:"manage_vault_token"`
 }
 
 type Vault struct {

--- a/rc/config.go
+++ b/rc/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	Version int               `yaml:"version"`
 	Current string            `yaml:"current"`
 	Vaults  map[string]*Vault `yaml:"vaults"`
+	Options Options           `yaml:"options"`
+}
+
+type Options struct {
+	ManageVaultToken bool `yaml:"manage_vault_token,omitempty"`
 }
 
 type Vault struct {
@@ -148,6 +153,9 @@ func (c *Config) Write() error {
 	b, err = yaml.Marshal(sv)
 	if err != nil {
 		return err
+	}
+	if c.Options.ManageVaultToken {
+		ioutil.WriteFile(fmt.Sprintf("%s/.vault-token", userHomeDir()), []byte(v.Token), 0600)
 	}
 
 	return ioutil.WriteFile(svtoken(), b, 0600)


### PR DESCRIPTION
Implements the basics for global target independent options for safe with the first being `manage_vault_token` to have safe automatically update the `~/.vault-token` file when targeting, authenticating, etc for ease of use with other tools (i.e. packer, terraform, etc that use the vault-token file)